### PR TITLE
Ticket - 26614 Disallow removal of ALL job sequences (need at least one) in TF6.

### DIFF
--- a/Legacy/addon/methods/viewers/delete/jobseq.i
+++ b/Legacy/addon/methods/viewers/delete/jobseq.i
@@ -10,7 +10,7 @@ DEFINE VARIABLE iRowCount AS INTEGER NO-UNDO.
        iRowCount = iRowCount + 1.
    END.
    IF iRowCount = 1 THEN DO:
-       MESSAGE 'Cannot delete job sequence. Need atleast one job sequence' VIEW-AS ALERT-BOX INFORMATION.
+       MESSAGE 'Cannot delete this job sequence. At least one job sequence is required.' VIEW-AS ALERT-BOX INFORMATION.
        RETURN ERROR.
    END.
    

--- a/Legacy/addon/methods/viewers/delete/jobseq.i
+++ b/Legacy/addon/methods/viewers/delete/jobseq.i
@@ -1,0 +1,17 @@
+/* jobseq.i */
+
+
+DEFINE BUFFER bf-jobseq FOR jobseq.
+DEFINE VARIABLE iRowCount AS INTEGER NO-UNDO.
+
+&IF '{&jobseq-delete}' NE '' &THEN
+
+   FOR EACH bf-jobseq NO-LOCK:
+       iRowCount = iRowCount + 1.
+   END.
+   IF iRowCount = 1 THEN DO:
+       MESSAGE 'Cannot delete job sequence. Need atleast one job sequence' VIEW-AS ALERT-BOX INFORMATION.
+       RETURN ERROR.
+   END.
+   
+&ENDIF

--- a/Legacy/addon/viewers/jobseq.w
+++ b/Legacy/addon/viewers/jobseq.w
@@ -35,6 +35,8 @@ CREATE WIDGET-POOL.
 
 /* Local Variable Definitions ---                                       */
 
+&SCOPED-DEFINE jobseq-delete jobseq-delete
+
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
 

--- a/Legacy/addon/windows/jobseq.w
+++ b/Legacy/addon/windows/jobseq.w
@@ -93,21 +93,21 @@ DEFINE FRAME F-Main
          SIDE-LABELS NO-UNDERLINE THREE-D 
          AT COL 1 ROW 1
          SIZE 94.2 BY 14
-         BGCOLOR 4 .
+         BGCOLOR 15 .
 
 DEFINE FRAME OPTIONS-FRAME
     WITH 1 DOWN NO-BOX KEEP-TAB-ORDER OVERLAY 
          SIDE-LABELS NO-UNDERLINE THREE-D 
          AT COL 2 ROW 1
          SIZE 93 BY 1.91
-         BGCOLOR 4 .
+         BGCOLOR 15 .
 
 DEFINE FRAME message-frame
     WITH 1 DOWN NO-BOX KEEP-TAB-ORDER OVERLAY 
          SIDE-LABELS NO-UNDERLINE THREE-D 
          AT COL 46 ROW 2.91
          SIZE 49 BY 1.43
-         BGCOLOR 4 .
+         BGCOLOR 15 .
 
 
 /* *********************** Procedure Settings ************************ */

--- a/Legacy/custom/delete.i
+++ b/Legacy/custom/delete.i
@@ -1,3 +1,3 @@
 /* custom/delete.i */
 
-emailcod loadtag ar-mcash itemfg ITEM period loc company po-ord shifts
+emailcod loadtag ar-mcash itemfg ITEM period loc company po-ord shifts jobseq 


### PR DESCRIPTION
Please review this change and merge into development branch.
Files - addon/viewers/jobseq.w, addon/windows/jobseq.w, custom/delete.i, addon/methods/viewers/delete/jobseq.i