### PR TITLE
Ticket - 27379 Help screen should always open on top

### DIFF
--- a/Legacy/addon/browsers/mhemp-exp.w
+++ b/Legacy/addon/browsers/mhemp-exp.w
@@ -782,7 +782,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/addon/browsers/mtrn-exp2.w
+++ b/Legacy/addon/browsers/mtrn-exp2.w
@@ -729,7 +729,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/addon/browsers/rd-mh1exp.w
+++ b/Legacy/addon/browsers/rd-mh1exp.w
@@ -781,7 +781,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/addon/browsers/rd-mh3exp.w
+++ b/Legacy/addon/browsers/rd-mh3exp.w
@@ -781,7 +781,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/addon/browsers/rd-mtrexp.w
+++ b/Legacy/addon/browsers/rd-mtrexp.w
@@ -729,7 +729,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/addon/windows/emp-exp.w
+++ b/Legacy/addon/windows/emp-exp.w
@@ -584,7 +584,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/addon/windows/emp-expe.w
+++ b/Legacy/addon/windows/emp-expe.w
@@ -586,7 +586,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/addon/windows/m-job-exp.w
+++ b/Legacy/addon/windows/m-job-exp.w
@@ -604,7 +604,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/apinq/apbl-exp.w
+++ b/Legacy/apinq/apbl-exp.w
@@ -653,7 +653,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/apinq/apck-exp.w
+++ b/Legacy/apinq/apck-exp.w
@@ -737,7 +737,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/apinq/apnq-exp.w
+++ b/Legacy/apinq/apnq-exp.w
@@ -584,7 +584,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/apinq/pcnq-exp.w
+++ b/Legacy/apinq/pcnq-exp.w
@@ -581,7 +581,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/arinq/csnq-exp.w
+++ b/Legacy/arinq/csnq-exp.w
@@ -748,7 +748,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/arinq/rd-invexp.w
+++ b/Legacy/arinq/rd-invexp.w
@@ -832,7 +832,7 @@ END.
 
 
 /* ***************************  Main Block  *************************** */
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT EQ ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/cec/citm-exp.w
+++ b/Legacy/cec/citm-exp.w
@@ -561,7 +561,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/fg/EstC-exp.w
+++ b/Legacy/fg/EstC-exp.w
@@ -563,7 +563,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/fg/EstF-exp.w
+++ b/Legacy/fg/EstF-exp.w
@@ -563,7 +563,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/fg/acc-exp.w
+++ b/Legacy/fg/acc-exp.w
@@ -585,7 +585,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/fg/carr-exp.w
+++ b/Legacy/fg/carr-exp.w
@@ -556,7 +556,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/fg/cust-exp.w
+++ b/Legacy/fg/cust-exp.w
@@ -651,7 +651,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/fg/fgnq-exp.w
+++ b/Legacy/fg/fgnq-exp.w
@@ -624,7 +624,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/fg/fitm-exp.w
+++ b/Legacy/fg/fitm-exp.w
@@ -555,7 +555,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/fg/m-mchexp.w
+++ b/Legacy/fg/m-mchexp.w
@@ -561,7 +561,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/fg/m-prtexp.w
+++ b/Legacy/fg/m-prtexp.w
@@ -558,7 +558,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/fg/m-smnexp.w
+++ b/Legacy/fg/m-smnexp.w
@@ -556,7 +556,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/fg/rd-fgexpN.w
+++ b/Legacy/fg/rd-fgexpN.w
@@ -1043,7 +1043,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/fg/rd-fgstxp.w
+++ b/Legacy/fg/rd-fgstxp.w
@@ -651,7 +651,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/fg/ship-exp.w
+++ b/Legacy/fg/ship-exp.w
@@ -689,7 +689,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT EQ ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/fg/sman-exp.w
+++ b/Legacy/fg/sman-exp.w
@@ -556,7 +556,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/fg/stlf-exp.w
+++ b/Legacy/fg/stlf-exp.w
@@ -544,7 +544,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/fg/styl-exp.w
+++ b/Legacy/fg/styl-exp.w
@@ -558,7 +558,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/fg/vend-exp.w
+++ b/Legacy/fg/vend-exp.w
@@ -558,7 +558,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/fginq/fgu-exp.w
+++ b/Legacy/fginq/fgu-exp.w
@@ -596,7 +596,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/jc/expjobs.w
+++ b/Legacy/jc/expjobs.w
@@ -320,7 +320,7 @@ END.
 
 
 /* ***************************  Main Block  *************************** */
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Set CURRENT-WINDOW: this will parent dialog-boxes and frames.        */
 ASSIGN CURRENT-WINDOW                = {&WINDOW-NAME} 
        THIS-PROCEDURE:CURRENT-WINDOW = {&WINDOW-NAME}.

--- a/Legacy/jc/jbcod-exp.w
+++ b/Legacy/jc/jbcod-exp.w
@@ -599,7 +599,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/oe/rd-invexp.w
+++ b/Legacy/oe/rd-invexp.w
@@ -802,7 +802,7 @@ END.
 
 
 /* ***************************  Main Block  *************************** */
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/oeinq/bol-expi.w
+++ b/Legacy/oeinq/bol-expi.w
@@ -860,7 +860,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/oeinq/rel-expi.w
+++ b/Legacy/oeinq/rel-expi.w
@@ -816,7 +816,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/oerep/rd-itcom.w
+++ b/Legacy/oerep/rd-itcom.w
@@ -550,7 +550,7 @@ END.
 
 
 /* ***************************  Main Block  *************************** */
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/oerep/rd-order.w
+++ b/Legacy/oerep/rd-order.w
@@ -835,7 +835,7 @@ END.
 
 
 /* ***************************  Main Block  *************************** */
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/oerep/rd-prmtx.w
+++ b/Legacy/oerep/rd-prmtx.w
@@ -566,7 +566,7 @@ END.
 
 
 /* ***************************  Main Block  *************************** */
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/oerep/rd-surcg.w
+++ b/Legacy/oerep/rd-surcg.w
@@ -385,7 +385,7 @@ END.
 
 
 /* ***************************  Main Block  *************************** */
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/po/rd-poexp.w
+++ b/Legacy/po/rd-poexp.w
@@ -965,7 +965,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/rm/dRMExport.w
+++ b/Legacy/rm/dRMExport.w
@@ -591,7 +591,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/rminq/rmiinq-exp.w
+++ b/Legacy/rminq/rmiinq-exp.w
@@ -722,7 +722,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/rminq/rmnq-exp.w
+++ b/Legacy/rminq/rmnq-exp.w
@@ -578,7 +578,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/rminq/routing-exp.w
+++ b/Legacy/rminq/routing-exp.w
@@ -585,7 +585,7 @@ END.
 
 /* ***************************  Main Block  *************************** */
 
-{sys/inc/f3helpw.i}
+{sys/inc/f3helpd.i}
 /* Parent the dialog-box to the ACTIVE-WINDOW, if there is no parent.   */
 IF VALID-HANDLE(ACTIVE-WINDOW) AND FRAME {&FRAME-NAME}:PARENT eq ?
 THEN FRAME {&FRAME-NAME}:PARENT = ACTIVE-WINDOW.

--- a/Legacy/sys/inc/f3helpd.i
+++ b/Legacy/sys/inc/f3helpd.i
@@ -25,7 +25,7 @@ message "Help Object Debug: self - "  self:name "," self:type skip
 
    if can-do("Browse,Frame",self:type) then
                          /* self:name or focus:name */
-            run sys/ref/hlpd.p (self:name, frame-file, frame-db,ls-prog-name, "English") .
-   else run sys/ref/hlpd.p (focus:name, focus:table, focus:dbname,"{&frame-name}", "English") .
+            run sys/ref/hlpd.w (self:name, frame-file, frame-db,ls-prog-name, "English") .
+   else run sys/ref/hlpd.w (focus:name, focus:table, focus:dbname,"{&frame-name}", "English") .
    return no-apply.
 end.

--- a/Legacy/sys/ref/hlp.w
+++ b/Legacy/sys/ref/hlp.w
@@ -443,7 +443,9 @@ IF NOT vhWebService:CONNECTED() THEN
     END. /* WebService no conn*/
 
     ELSE DO:
-       
+      IF ip-table EQ ? THEN ip-table = "" .
+      IF ip-field EQ ? THEN ip-field = "" .
+      IF ip-frame EQ ? THEN ip-frame = "" .  
     RUN Service1Soap SET vhSalesSoap ON vhWebService .
     RUN HelpMain IN vhSalesSoap(INPUT STRING(ip-field),INPUT STRING(ip-table),INPUT STRING(ip-frame),INPUT STRING(vclint),  OUTPUT parameters1,OUTPUT parameters2,OUTPUT fr-flags ).
      

--- a/Legacy/sys/ref/hlp.w
+++ b/Legacy/sys/ref/hlp.w
@@ -110,7 +110,7 @@ DEFINE BUTTON Btn_OK AUTO-END-KEY
      BGCOLOR 8 .
 
 DEFINE VARIABLE ed-text AS CHARACTER 
-     VIEW-AS EDITOR MAX-CHARS 300000 SCROLLBAR-VERTICAL
+     VIEW-AS EDITOR MAX-CHARS 500000 SCROLLBAR-VERTICAL
      SIZE 115 BY 18.57
      FONT 0 NO-UNDO.
 
@@ -307,8 +307,7 @@ DO:
     
     /* If not automatically cleared by security level, ask for password */
     IF lResult THEN DO:
-        RUN sys/ref/uphlp-pass.w (3, OUTPUT lResult).
-        IF lResult THEN 
+       
             RUN sys/ref/hlpupd.w (ip-field,ip-table,ip-db,ip-frame,ip-language,OUTPUT op-ed-text).
     END.
 


### PR DESCRIPTION
Please review this change and merge into development branch 
Files - addon\browsers\mhemp-exp.w,addon\browsers\mtrn-exp2.w,addon\browsers\rd-mh1exp.w,addon\browsers\rd-mh3exp.w,
addon\browsers\rd-mtrexp.w,addon\windows\emp-exp.w,addon\windows\emp-expe.w,apinq\apbl-exp.w,
apinq\apck-exp.w,apinq\apnq-exp.w,apinq\pcnq-exp.w,arinq\rd-invexp.w,cec\citm-exp.w,fg\acc-exp.w,
fg\carr-exp.w,fg\cust-exp.w,fg\EstC-exp.w,fg\EstF-exp.w,fg\fgnq-exp.w,fg\fitm-exp.w,fg\m-mchexp.w,
fg\m-prtexp.w,fg\m-smnexp.w,fg\rd-fgexpN.w,fg\rd-fgstxp.w,fg\ship-exp.w,fg\sman-exp.w,fg\stlf-exp.w,
fg\styl-exp.w,fg\vend-exp.w,fginq\fgu-exp.w,jc\expjobs.w,jc\jbcod-exp.w,oe\rd-invexp.w,oeinq\bol-expi.w,
oeinq\rel-expi.w,oerep\rd-order.w,oerep\rd-prmtx.w,oerep\rd-surcg.w,po\rd-poexp.w,rminq\rmiinq-exp.w,
rminq\rmnq-exp.w,rminq\routing-exp.w,