### PR TITLE
26482 dbconnection file should not be tracked

### DIFF
--- a/Legacy/.dbconnection
+++ b/Legacy/.dbconnection
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<connection>
-<connectionentry identifier="asi"/>
-<connectionentry identifier="Audit"/>
-</connection>


### PR DESCRIPTION
Before merging, need to notify developers to backup their .dbconnection file just in case this removes it - just to be on the safe side.