### PR TITLE
#29056 Advantzware Logon

### DIFF
--- a/Legacy/viewers/users.w
+++ b/Legacy/viewers/users.w
@@ -1152,7 +1152,7 @@ PROCEDURE ipWriteUsrFile :
     OUTPUT TO VALUE(cUsrLoc).
     FOR EACH ttUsers:
         PUT UNFORMATTED
-            ttUsers.ttfPdbname + "|" +
+            "*|" +
             ttUsers.ttfUserAlias + "|" +
             ttUsers.ttfUserID + "|" +
             ttUsers.ttfEnvList + "|" +
@@ -1358,7 +1358,7 @@ PROCEDURE local-delete-record :
     END.
     
     FIND ttUsers EXCLUSIVE WHERE
-        ttUsers.ttfPdbname = PDBNAME(1) AND
+        ttUsers.ttfPdbname = "*" AND
         ttUsers.ttfUserID = users.user_id:SCREEN-VALUE IN FRAME {&FRAME-NAME}
         NO-ERROR.
     IF AVAIL ttUsers THEN DO:
@@ -1408,13 +1408,13 @@ PROCEDURE local-display-fields :
     
     IF AVAIL users THEN DO:
         FIND FIRST ttUsers WHERE
-            ttUsers.ttfPdbName = PDBNAME(1) AND
+            ttUsers.ttfPdbName = "*" AND
             ttUsers.ttfUserID = users.user_id
             NO-ERROR.
         IF NOT AVAIL ttUsers THEN DO:
             CREATE ttUsers.
             ASSIGN
-                ttUsers.ttfPdbName = PDBNAME(1)
+                ttUsers.ttfPdbName = "*"
                 ttUsers.ttfUserID = users.user_id
                 ttUsers.ttfEnvList = slEnvironments:list-items in FRAME {&FRAME-NAME}
                 ttUsers.ttfDbList = slDatabases:list-items
@@ -1729,13 +1729,13 @@ PROCEDURE local-update-record :
     END.
 
     FIND ttUsers EXCLUSIVE WHERE
-        ttUsers.ttfPdbname = PDBNAME(1) AND
+        ttUsers.ttfPdbName = "*" AND
         ttUsers.ttfUserID = users.user_id:SCREEN-VALUE
         NO-ERROR.
     IF NOT AVAIL ttUsers THEN DO:
         CREATE ttUsers.
         ASSIGN
-            ttUsers.ttfPdbname = PDBNAME(1)
+            ttUsers.ttfPdbname = "*"
             ttUsers.ttfUserID = users.user_id:SCREEN-VALUE.
     END.
     ASSIGN

--- a/PatchTemplate/Deployment/Admin/EnvAdmin/asiLogin.w
+++ b/PatchTemplate/Deployment/Admin/EnvAdmin/asiLogin.w
@@ -651,14 +651,16 @@ END.
 ON LEAVE OF fiUserID IN FRAME DEFAULT-FRAME /* User ID */
 DO:
     FIND FIRST ttUsers NO-LOCK WHERE
-        ttUsers.ttfUserID = SELF:{&SV} AND
-        ttUsers.ttfPdbName = cbDatabase:{&SV}
+        ttUsers.ttfPdbName = "*" AND
+        ttUsers.ttfUserID = SELF:{&SV} 
         NO-ERROR.
     IF NOT AVAIL ttUsers THEN DO:
         FIND FIRST ttUsers NO-LOCK WHERE
+            ttUsers.ttfPdbName = "*" AND
             ttUsers.ttfUserAlias = SELF:{&SV}
             NO-ERROR.
     END.
+    
     IF NOT AVAIL ttUsers THEN DO:
         MESSAGE
             "Unable to locate this user in the advantzware.usr file." SKIP
@@ -1587,21 +1589,20 @@ PROCEDURE ipUpdUsrFile :
     
     DO iCtr = 1 TO NUM-ENTRIES(ipcUserList):
         FIND FIRST ttUsers WHERE
-            ttUsers.ttfPdbname = PDBNAME(1) AND
+            ttUsers.ttfPdbName = "*"
             ttUsers.ttfUserID = ENTRY(iCtr,ipcUserList)
             NO-LOCK NO-ERROR.
         IF NOT AVAIL ttUsers THEN DO:
             CREATE ttUsers.
             ASSIGN
                 lUpdUsr = TRUE
-                ttUsers.ttfPdbname = PDBNAME(1)
+                ttUsers.ttfPdbname = "*"
                 ttUsers.ttfUserID = ENTRY(iCtr,ipcUserList)
                 ttUsers.ttfUserAlias = ENTRY(iCtr,ipcUserList)
                 .
         END.
     END.
-    FOR EACH ttUsers WHERE
-        ttUsers.ttfPdbname = PDBNAME(1):
+    FOR EACH ttUsers:
         IF LOOKUP(ttUsers.ttfUserID,ipcUserList) = 0 THEN DO:
             DELETE ttUsers.
         END.
@@ -1610,7 +1611,7 @@ PROCEDURE ipUpdUsrFile :
         OUTPUT STREAM usrStream TO VALUE(cUsrLoc).
         FOR EACH ttUsers BY ttUsers.ttfPdbname by ttUsers.ttfUserID:
             ASSIGN cOutString = 
-                ttUsers.ttfPdbname + "|" +
+                "*|" +
                 ttUsers.ttfUserAlias + "|" + 
                 ttUsers.ttfUserID + "|" + 
                 ttUsers.ttfEnvList + "|" +


### PR DESCRIPTION
While working in this area, discovered scenarios where a user id associated with one database had certain permissions, while the same user in another database had different permissions. Since neither database is connected when logging in, the login program was not able to distinguish between the two. As a short-term solution, ensured that one userid had the same permissions in all connected databases, so that if an admin changes permissions in one, that change is propagated to all.
Test case:
open 16.7.8, change user mode list
open 16.6.12, changes just made will reflect in user record