### PR TITLE
28397 - Upgrade issue when one environment at version 16.7.0

### DIFF
--- a/PatchTemplate/Deployment/Admin/EnvAdmin/asiLogin.w
+++ b/PatchTemplate/Deployment/Admin/EnvAdmin/asiLogin.w
@@ -1012,7 +1012,8 @@ PROCEDURE ipClickOk :
     END.
 
     /* Advise that code at lower levels will not be able to update user properties correctly */
-    IF iEnvLevel LT 16070800 THEN DO:
+    IF iEnvLevel LT 16070800 
+    AND fiUserid:{&SV} = "admin" THEN DO:
         MESSAGE
             "Changes to user aliases, mode, environments and databases will not be saved with this version."
             VIEW-AS ALERT-BOX INFO.
@@ -1066,8 +1067,7 @@ PROCEDURE ipConnectDb :
         cStatement = cStatement + " -U " + cUserID + " -P '" + fiPassword + "'".
     ELSE ASSIGN
         cStatement = cStatement + " -U " + cUserID.
-    CONNECT VALUE(cStatement) NO-ERROR.
-
+    CONNECT VALUE(cStatement).
     IF ERROR-STATUS:ERROR THEN DO:
         DO iCtr = 1 TO ERROR-STATUS:NUM-MESSAGES:
             /* Strip off the "Progress-y" elements of the error */
@@ -1122,10 +1122,10 @@ PROCEDURE ipConnectDb :
             xDbName = ENTRY(iLookup,cAudDbList)
             xdbPort = ENTRY(iLookup,cAudPortList)
             connectStatement = "".
-        IF iEnvLEvel EQ 16070000 THEN ASSIGN
+/*        IF iEnvLEvel EQ 16070000 THEN ASSIGN
             xDBName = "audTest166"
             xdbPort = "2837".
-        IF xDbName NE "" THEN DO:
+*/        IF xDbName NE "" THEN DO:
             ASSIGN
                 connectStatement = "-db " + xDbName + 
                                    " -H " + chostName +


### PR DESCRIPTION
asiLogin program contained conditional code that was specific to AWS environment set.  Removed in favor of list-based logid.