### PR TITLE
39730 Estimating record lock when two people are in the same estimate

### DIFF
--- a/Legacy/ce/v-est3.w
+++ b/Legacy/ce/v-est3.w
@@ -2803,6 +2803,7 @@ PROCEDURE find-depth-reftable :
     END.
 
     op-rowid = ROWID(b-rt).
+    RELEASE b-rt.
   END.
 END PROCEDURE.
 


### PR DESCRIPTION
Forced release of reftable when being created.