### PR TITLE
40720 Updating release give current year as 0018 - not 2018

### DIFF
--- a/Legacy/methods/calpopup.i
+++ b/Legacy/methods/calpopup.i
@@ -1,10 +1,24 @@
-/* calendar.i */
+/* methods/calpopup.i */
+/* Tkt #40720 Mod 12/12/18 - MYT - support misc string variable formats */
 
 &IF DEFINED(Calendar) = 0 &THEN
 &Scoped-define Calendar YES
 DEFINE VARIABLE calendarDate AS CHARACTER NO-UNDO.
+DEFINE VARIABLE daCalDate AS DATE NO-UNDO.
 &ENDIF
 RUN nosweat/popupcal2.w (OUTPUT calendarDate).
-IF calendarDate NE '' THEN
-SELF:SCREEN-VALUE = calendarDate.
+if calendarDate NE "" then do:
+    assign 
+        daCalDate = date(calendarDate).
+    if self:format EQ "99/99/9999" then assign
+        self:screen-value = string(daCalDate,"99/99/9999").
+    else if self:format = "99/99/99" then assign
+        self:screen-value = string(daCalDate,"99/99/99").
+    else assign
+        self:screen-value = string(daCalDate).
+end.
+/*
+* IF calendarDate NE '' THEN
+* SELF:SCREEN-VALUE = calendarDate.
+*/
 RETURN NO-APPLY.


### PR DESCRIPTION
Program changed: methods/calpopup.i
added formatting specifics for text files displaying as dates
Programs affected: oe/d-ordrel.w and po/s-poordl.w