### PR TITLE
41297 Module.r program at protogon had security level set at 900 rath…

### DIFF
--- a/PatchTemplate/Deployment/Admin/EnvAdmin/asiUpdateEnv.w
+++ b/PatchTemplate/Deployment/Admin/EnvAdmin/asiUpdateEnv.w
@@ -3714,7 +3714,7 @@ PROCEDURE ipLoadUtilitiesTable :
     REPEAT:
         CREATE {&tablename}.
         IMPORT {&tablename}.
-        IF {&tablename}.programName = "module" THEN ASSIGN 
+        IF {&tablename}.programName = "module.r" THEN ASSIGN 
             {&tablename}.securityLevel = 1000.
         ELSE ASSIGN 
             {&tablename}.securityLevel = 900.


### PR DESCRIPTION
…er than 1000

corrected error in load of utilities table to test for "module.r", not "module", to prevent set of permission level to 900