### PR TITLE
Feature/41926 remove deprecated references to asi load

### DIFF
--- a/Legacy/nosweat.i
+++ b/Legacy/nosweat.i
@@ -91,9 +91,9 @@ RUN userRecordCheck.
 &ENDIF
 
 
-&IF "{&runAsiLoad}" EQ "YES"  &THEN
-RUN asiload.p.
-&ENDIF
+/*&IF "{&runAsiLoad}" EQ "YES"  &THEN*/
+/*RUN asiload.p.                     */
+/*&ENDIF                             */
 
 RUN chkdate.p.
   

--- a/Legacy/nosweat.i
+++ b/Legacy/nosweat.i
@@ -91,9 +91,9 @@ RUN userRecordCheck.
 &ENDIF
 
 
-&IF "{&runAsiLoad}" EQ "YES"  &THEN
-RUN asiload.p.
-&ENDIF
+/*&IF "{&runAsiLoad}" EQ "YES"  &THEN*/ 
+/*RUN asiload.p.                     */
+/*&ENDIF                             */
 
 RUN chkdate.p.
   

--- a/Legacy/nosweat.i
+++ b/Legacy/nosweat.i
@@ -91,9 +91,9 @@ RUN userRecordCheck.
 &ENDIF
 
 
-/*&IF "{&runAsiLoad}" EQ "YES"  &THEN*/
-/*RUN asiload.p.                     */
-/*&ENDIF                             */
+&IF "{&runAsiLoad}" EQ "YES"  &THEN
+RUN asiload.p.
+&ENDIF
 
 RUN chkdate.p.
   

--- a/Legacy/system/mainMenu.w
+++ b/Legacy/system/mainMenu.w
@@ -2627,13 +2627,6 @@ PROCEDURE pInit :
                 RUN HelpVersion IN hSalesSoap (OUTPUT cVersion).
                 ASSIGN
                     cThisVer     = "{&awversion}"
-                    /* Convert single digit entries to dbl-digit, so that "5" is greater than "41", etc. */
-                    ENTRY(1,cVersion,".") = IF INTEGER(ENTRY(1,cVersion,".")) LT 10 THEN STRING(ENTRY(1,cVersion,".") * 10) ELSE ENTRY(1,cVersion,".")  
-                    ENTRY(2,cVersion,".") = IF INTEGER(ENTRY(2,cVersion,".")) LT 10 THEN STRING(ENTRY(2,cVersion,".") * 10) ELSE ENTRY(2,cVersion,".")  
-                    ENTRY(3,cVersion,".") = IF INTEGER(ENTRY(3,cVersion,".")) LT 10 THEN STRING(ENTRY(3,cVersion,".") * 10) ELSE ENTRY(3,cVersion,".")  
-                    ENTRY(1,cThisVer,".") = IF INTEGER(ENTRY(1,cThisVer,".")) LT 10 THEN STRING(ENTRY(1,cThisVer,".") * 10) ELSE ENTRY(1,cThisVer,".")  
-                    ENTRY(2,cThisVer,".") = IF INTEGER(ENTRY(2,cThisVer,".")) LT 10 THEN STRING(ENTRY(2,cThisVer,".") * 10) ELSE ENTRY(2,cThisVer,".")  
-                    ENTRY(3,cThisVer,".") = IF INTEGER(ENTRY(3,cThisVer,".")) LT 10 THEN STRING(ENTRY(3,cThisVer,".") * 10) ELSE ENTRY(3,cThisVer,".")  
                     iLastVersion = (INTEGER(ENTRY(1,cVersion,".")) * 10000) +
                                    (INTEGER(ENTRY(2,cVersion,".")) * 100) +
                                    (INTEGER(ENTRY(3,cVersion,".")))

--- a/Legacy/system/mainMenu.w
+++ b/Legacy/system/mainMenu.w
@@ -2627,6 +2627,13 @@ PROCEDURE pInit :
                 RUN HelpVersion IN hSalesSoap (OUTPUT cVersion).
                 ASSIGN
                     cThisVer     = "{&awversion}"
+                    /* Convert single digit entries to dbl-digit, so that "5" is greater than "41", etc. */
+                    ENTRY(1,cVersion,".") = IF INTEGER(ENTRY(1,cVersion,".")) LT 10 THEN STRING(ENTRY(1,cVersion,".") * 10) ELSE ENTRY(1,cVersion,".")  
+                    ENTRY(2,cVersion,".") = IF INTEGER(ENTRY(2,cVersion,".")) LT 10 THEN STRING(ENTRY(2,cVersion,".") * 10) ELSE ENTRY(2,cVersion,".")  
+                    ENTRY(3,cVersion,".") = IF INTEGER(ENTRY(3,cVersion,".")) LT 10 THEN STRING(ENTRY(3,cVersion,".") * 10) ELSE ENTRY(3,cVersion,".")  
+                    ENTRY(1,cThisVer,".") = IF INTEGER(ENTRY(1,cThisVer,".")) LT 10 THEN STRING(ENTRY(1,cThisVer,".") * 10) ELSE ENTRY(1,cThisVer,".")  
+                    ENTRY(2,cThisVer,".") = IF INTEGER(ENTRY(2,cThisVer,".")) LT 10 THEN STRING(ENTRY(2,cThisVer,".") * 10) ELSE ENTRY(2,cThisVer,".")  
+                    ENTRY(3,cThisVer,".") = IF INTEGER(ENTRY(3,cThisVer,".")) LT 10 THEN STRING(ENTRY(3,cThisVer,".") * 10) ELSE ENTRY(3,cThisVer,".")  
                     iLastVersion = (INTEGER(ENTRY(1,cVersion,".")) * 10000) +
                                    (INTEGER(ENTRY(2,cVersion,".")) * 100) +
                                    (INTEGER(ENTRY(3,cVersion,".")))

--- a/Legacy/system/mainMenu.w
+++ b/Legacy/system/mainMenu.w
@@ -2626,7 +2626,14 @@ PROCEDURE pInit :
                 RUN Service1Soap SET hSalesSoap ON hWebService .
                 RUN HelpVersion IN hSalesSoap (OUTPUT cVersion).
                 ASSIGN
-                    cThisVer     = "{&awversion}"
+                    cThisVer     = "{&awversion}" 
+                    /* Convert single digit entries to dbl-digit, so that "5" is greater than "41", etc. */
+                    ENTRY(1,cVersion,".") = IF INTEGER(ENTRY(1,cVersion,".")) LT 10 THEN STRING(ENTRY(1,cVersion,".") * 10) ELSE ENTRY(1,cVersion,".")  
+                    ENTRY(2,cVersion,".") = IF INTEGER(ENTRY(2,cVersion,".")) LT 10 THEN STRING(ENTRY(2,cVersion,".") * 10) ELSE ENTRY(2,cVersion,".")  
+                    ENTRY(3,cVersion,".") = IF INTEGER(ENTRY(3,cVersion,".")) LT 10 THEN STRING(ENTRY(3,cVersion,".") * 10) ELSE ENTRY(3,cVersion,".")  
+                    ENTRY(1,cThisVer,".") = IF INTEGER(ENTRY(1,cThisVer,".")) LT 10 THEN STRING(ENTRY(1,cThisVer,".") * 10) ELSE ENTRY(1,cThisVer,".")  
+                    ENTRY(2,cThisVer,".") = IF INTEGER(ENTRY(2,cThisVer,".")) LT 10 THEN STRING(ENTRY(2,cThisVer,".") * 10) ELSE ENTRY(2,cThisVer,".")  
+                    ENTRY(3,cThisVer,".") = IF INTEGER(ENTRY(3,cThisVer,".")) LT 10 THEN STRING(ENTRY(3,cThisVer,".") * 10) ELSE ENTRY(3,cThisVer,".")  
                     iLastVersion = (INTEGER(ENTRY(1,cVersion,".")) * 10000) +
                                    (INTEGER(ENTRY(2,cVersion,".")) * 100) +
                                    (INTEGER(ENTRY(3,cVersion,".")))

--- a/PatchTemplate/Deployment/Admin/EnvAdmin/asiLogin.w
+++ b/PatchTemplate/Deployment/Admin/EnvAdmin/asiLogin.w
@@ -1682,8 +1682,9 @@ PROCEDURE ipPreRun :
     IF iDbLevel GT 16061200 THEN 
         RUN epSetUpEDI IN hPreRun.
 
-    IF fiUserID = "ASI" THEN 
-        RUN asiload.p.
+/*    #41926 Remove deprecated references to asiLoad  */
+/*    IF fiUserID = "ASI" THEN*/
+/*        RUN asiload.p.      */
 
     RUN epCheckExpiration IN hPreRun (OUTPUT lOK).
     IF NOT lOK THEN QUIT.

--- a/PatchTemplate/Deployment/Admin/EnvAdmin/asiLogin.w
+++ b/PatchTemplate/Deployment/Admin/EnvAdmin/asiLogin.w
@@ -1682,9 +1682,8 @@ PROCEDURE ipPreRun :
     IF iDbLevel GT 16061200 THEN 
         RUN epSetUpEDI IN hPreRun.
 
-/*    #41926 Remove deprecated references to asiLoad  */
-/*    IF fiUserID = "ASI" THEN*/
-/*        RUN asiload.p.      */
+    IF fiUserID = "ASI" THEN 
+        RUN asiload.p.
 
     RUN epCheckExpiration IN hPreRun (OUTPUT lOK).
     IF NOT lOK THEN QUIT.


### PR DESCRIPTION
41926 Remove deprecated references to asiLoad
Programs changed:  system/mainmenu.w, nosweat.i, admin/envadmin/asiLogin.w
removed references as per spec
also, modified mainMenu versioning to improve integer calculations (see line 2630)