### PR TITLE
42196 Modes, Environments and Databases set in the User not working

### DIFF
--- a/PatchTemplate/Deployment/Admin/EnvAdmin/asiLogin.w
+++ b/PatchTemplate/Deployment/Admin/EnvAdmin/asiLogin.w
@@ -1515,16 +1515,8 @@ PROCEDURE ipFindUsrFile :
     
     ASSIGN
         cUsrLoc = ipUserFileName.
-        
     /* Start guessing where the file might be */
     DO:
-        IF SEARCH(cUsrLoc) <> ? THEN DO:
-            ASSIGN
-                cUsrLoc = SEARCH(cUsrLoc).
-            LEAVE.
-        END.
-        ELSE ASSIGN
-            cUsrLoc = "..\" + ipUserFileName.
         IF SEARCH(cUsrLoc) <> ? THEN DO:
             ASSIGN
                 cUsrLoc = SEARCH(cUsrLoc).
@@ -1603,8 +1595,6 @@ PROCEDURE ipFindUsrFile :
         ASSIGN
             cUsrLoc = "".
     END.
-    
-    
     
 END PROCEDURE.
 


### PR DESCRIPTION
Program Changed: asiLogin.w
noted that (in our AWS environment), the asiLogin program was finding an advantzware.usr file in a "relative" directory (..\advantzware.usr).  This would not be the case at a customer site.  Modified asiLogin.w to prevent this option when searching for the .usr file.