### PR TITLE
44776 Need to default data digger fonts and set to not be automatic

### DIFF
--- a/Legacy/DataDigger/DataDigger-Administrator.ini
+++ b/Legacy/DataDigger/DataDigger-Administrator.ini
@@ -119,8 +119,8 @@ lShow:Visible=yes
 
 [DataDigger:fonts]
 AutoSetFont=no
-default=4
-fixed=0
+default=10
+fixed=10
 
 [DataDigger:help]
 RereadNoLock:answer=1


### PR DESCRIPTION
File changed: DataDigger-Administrator.ini
Whenever a user logs into DD, the pgm creates a "personalized" .ini file that includes default settings.  Cannot tell from code, but I believe this .ini file is used as the template for other users.
Changed defaults as per spec in this template.