### PR TITLE
45391 Major Bug in Corrugated Estimating - No Scoring Allowances.

### DIFF
--- a/Legacy/cec/v-est.w
+++ b/Legacy/cec/v-est.w
@@ -3533,9 +3533,9 @@ DO WITH FRAME {&FRAME-NAME}:
   END.
   ELSE do:
       ASSIGN
-        eb.t-wid:FORMAT = ">>>>9.999<<"
+        eb.t-wid:FORMAT = ">>>>9.99<<<"
         eb.t-wid:WIDTH = 15.2
-        eb.t-len:FORMAT = ">>>>9.999<<"
+        eb.t-len:FORMAT = ">>>>9.99<<<"
         eb.t-len:WIDTH = 15.2 .
 
       IF eb.t-sqin GT 999999  THEN


### PR DESCRIPTION
File changed:  cec/v-est.w
Modified format for blank length and width when UoM is 16ths
(Note: sqin will still show up to 5 decimal places; this CAN introduce rounding errors, as true precision would require up to 8 places, but this level of precision is highly unlikely to be required)