### PR TITLE
45391 Major Bug in Corrugated Estimating - No Scoring Allowances.

### DIFF
--- a/Legacy/cec/v-est2.w
+++ b/Legacy/cec/v-est2.w
@@ -3458,8 +3458,8 @@ PROCEDURE local-display-fields :
      END.
      ELSE do:
          ASSIGN
-             eb.t-len:FORMAT = ">>>>9.999<<"
-             eb.t-dep:FORMAT = ">>>>9.999<<" .
+             eb.t-len:FORMAT = ">>>>9.99<<<"
+             eb.t-dep:FORMAT = ">>>>9.99<<<" .
 
          IF eb.t-sqin GT 999999  THEN
              ASSIGN


### PR DESCRIPTION
File changed:  cec/v-est2.w
Modified format for blank length and depth when UoM is 16ths