### PR TITLE
47459 Upgrade Program - post 16.8.8 release fixes needed

### DIFF
--- a/Template/BuildScript/ToCompile/asiLogin.w
+++ b/Template/BuildScript/ToCompile/asiLogin.w
@@ -201,7 +201,7 @@ ELSE DO:
 END.
         
 /* Find the .ini file containing variables and values */
-RUN ipFindIniFile ("N:\Admin\advantzware.ini",
+RUN ipFindIniFile ("..\advantzware.ini",
                    OUTPUT cIniLoc).
 
 IF cIniLoc EQ "" THEN DO:

--- a/Template/BuildScript/ToCompile/asiUpdateEnv.w
+++ b/Template/BuildScript/ToCompile/asiUpdateEnv.w
@@ -49,6 +49,7 @@ DEF INPUT PARAMETER ipcToVer AS CHAR NO-UNDO.
 DEF INPUT PARAMETER ipiLevel AS INT NO-UNDO.
 DEF INPUT PARAMETER iplNeedBackup AS LOG NO-UNDO.
 DEF OUTPUT PARAMETER oplSuccess AS LOG NO-UNDO.
+DEF INPUT-OUTPUT PARAMETER iopiStatus AS INT NO-UNDO.
 
 /*
 /* FOR TEST PURPOSES ONLY */
@@ -190,7 +191,6 @@ DEF VAR v4 LIKE lookups.prgmname NO-UNDO.
 DEF VAR v5 LIKE lookups.rec_key NO-UNDO.
 DEF VAR xDbDir AS CHAR NO-UNDO.
 
-
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
 
@@ -206,7 +206,7 @@ DEF VAR xDbDir AS CHAR NO-UNDO.
 &Scoped-define FRAME-NAME DEFAULT-FRAME
 
 /* Standard List Definitions                                            */
-&Scoped-Define ENABLED-OBJECTS RECT-5 tbBackupDBs tbUserControl ~
+&Scoped-Define ENABLED-OBJECTS RECT-5 RECT-6 tbBackupDBs tbUserControl ~
 tbUserCleanup tbDelBadData tbUpdateMaster tbRunDataFix tbUpdateNK1s ~
 fiLicensedUsers tbReftableConv bProcess tbLoadMenus tbRelNotes eStatus ~
 tbInstallFiles tbUpdateIni 
@@ -233,15 +233,12 @@ FUNCTION fFixYear RETURNS DATE
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
 
-
-&ANALYZE-SUSPEND _UIB-CODE-BLOCK _FUNCTION-FORWARD fIntVer C-Win
-FUNCTION fIntVer RETURNS INTEGER 
+&ANALYZE-SUSPEND _UIB-CODE-BLOCK _FUNCTION-FORWARD fIntVer C-Win 
+FUNCTION fIntVer RETURNS INTEGER
   ( INPUT cVerString AS CHAR ) FORWARD.
 
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
-
-
 
 
 /* ***********************  Control Definitions  ********************** */
@@ -316,6 +313,16 @@ DEFINE VARIABLE fiToVer AS CHARACTER FORMAT "X(256)":U
 DEFINE RECTANGLE RECT-5
      EDGE-PIXELS 2 GRAPHIC-EDGE  NO-FILL   
      SIZE 39 BY 14.76.
+
+DEFINE RECTANGLE RECT-6
+     EDGE-PIXELS 1 GRAPHIC-EDGE  NO-FILL   
+     SIZE 75 BY 1.43
+     FGCOLOR 3 .
+
+DEFINE RECTANGLE rStatusBar
+     EDGE-PIXELS 1 GRAPHIC-EDGE    
+     SIZE 10 BY 1.43
+     BGCOLOR 3 FGCOLOR 3 .
 
 DEFINE VARIABLE tbBackupDBs AS LOGICAL INITIAL no 
      LABEL "Backup Databases" 
@@ -421,10 +428,12 @@ DEFINE FRAME DEFAULT-FRAME
      "Status:" VIEW-AS TEXT
           SIZE 8 BY .62 AT ROW 11.71 COL 3 WIDGET-ID 54
      RECT-5 AT ROW 1.48 COL 87
+     rStatusBar AT ROW 16.71 COL 3
+     RECT-6 AT ROW 16.71 COL 3
     WITH 1 DOWN NO-BOX KEEP-TAB-ORDER OVERLAY 
          SIDE-LABELS NO-UNDERLINE THREE-D 
          AT COL 1 ROW 1
-         SIZE 130 BY 15.43 WIDGET-ID 100.
+         SIZE 130 BY 17.86 WIDGET-ID 100.
 
 
 /* *********************** Procedure Settings ************************ */
@@ -443,7 +452,9 @@ IF SESSION:DISPLAY-TYPE = "GUI":U THEN
   CREATE WINDOW C-Win ASSIGN
          HIDDEN             = YES
          TITLE              = "Advantzware Update - Programs/Data"
-         HEIGHT             = 15.48
+         COLUMN             = 10
+         ROW                = 5
+         HEIGHT             = 17.91
          WIDTH              = 130
          MAX-HEIGHT         = 34.29
          MAX-WIDTH          = 166.2
@@ -490,6 +501,8 @@ ELSE {&WINDOW-NAME} = CURRENT-WINDOW.
 /* SETTINGS FOR FILL-IN fiSiteName IN FRAME DEFAULT-FRAME
    NO-ENABLE                                                            */
 /* SETTINGS FOR FILL-IN fiToVer IN FRAME DEFAULT-FRAME
+   NO-ENABLE                                                            */
+/* SETTINGS FOR RECTANGLE rStatusBar IN FRAME DEFAULT-FRAME
    NO-ENABLE                                                            */
 /* SETTINGS FOR TOGGLE-BOX tbBackupFiles IN FRAME DEFAULT-FRAME
    NO-ENABLE                                                            */
@@ -592,9 +605,10 @@ DO ON ERROR   UNDO MAIN-BLOCK, LEAVE
         fiFromVer:{&SV}     = ipcFromVer
         fiToVer:{&SV}       = ipcToVer
         fiAsiDbName:{&SV}   = ipcName
-        fiAsiPortNo:{&SV}   = ipcPort.
+        fiAsiPortNo:{&SV}   = ipcPort
+        rStatusBar:WIDTH    = MIN(75,(iopiStatus / 100) * 75).
 
-    RUN ipFindIniFile ("N:\Admin\advantzware.ini",
+    RUN ipFindIniFile ("..\advantzware.ini",
                        OUTPUT cIniLoc).
     IF cIniLoc NE "" THEN 
         RUN ipReadIniFile.
@@ -639,7 +653,7 @@ DO ON ERROR   UNDO MAIN-BLOCK, LEAVE
         
     IF ipiLevel LT 10 THEN DO:
         ASSIGN
-            c-Win:WIDTH = 77
+            c-Win:WIDTH = 79.8
             bProcess:LABEL = "No User Action Required"
             lAutorun = TRUE.
         DISABLE ALL EXCEPT bProcess eStatus WITH FRAME {&FRAME-NAME}.
@@ -694,7 +708,7 @@ PROCEDURE enable_UI :
           tbLoadMenus tbRelNotes eStatus tbBackupFiles tbInstallFiles 
           tbUpdateIni 
       WITH FRAME DEFAULT-FRAME IN WINDOW C-Win.
-  ENABLE RECT-5 tbBackupDBs tbUserControl tbUserCleanup tbDelBadData 
+  ENABLE RECT-5 RECT-6 tbBackupDBs tbUserControl tbUserCleanup tbDelBadData 
          tbUpdateMaster tbRunDataFix tbUpdateNK1s fiLicensedUsers 
          tbReftableConv bProcess tbLoadMenus tbRelNotes eStatus tbInstallFiles 
          tbUpdateIni 
@@ -736,9 +750,8 @@ END PROCEDURE.
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
 
-
-&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipAddDbmsFonts C-Win
-PROCEDURE ipAddDbmsFonts:
+&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipAddDbmsFonts C-Win 
+PROCEDURE ipAddDbmsFonts :
 /*------------------------------------------------------------------------------
  Purpose:
  Notes:
@@ -826,11 +839,9 @@ PROCEDURE ipAddDbmsFonts:
     END.
 
 END PROCEDURE.
-	
+
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
-
-
 
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipAddLocationData C-Win 
 PROCEDURE ipAddLocationData :
@@ -972,6 +983,7 @@ PROCEDURE ipArchiveFiles :
     
     FILE-INFO:FILE-NAME = cEnvProdDir.
     ASSIGN
+        lSuccess = FALSE 
         lProdExists = FILE-INFO:FULL-PATHNAME NE ?.
         
     IF SEARCH(cUpdProgramDir + "\programs.7z") NE ? THEN DO:
@@ -1060,14 +1072,16 @@ PROCEDURE ipArchiveFiles :
         OS-COMMAND SILENT VALUE(cCmdZip).
     END.
 
+    ASSIGN 
+        lSuccess = TRUE.
+
 END PROCEDURE.
 
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
 
-
-&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipAuditSysCtrl C-Win
-PROCEDURE ipAuditSysCtrl:
+&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipAuditSysCtrl C-Win 
+PROCEDURE ipAuditSysCtrl :
 /*------------------------------------------------------------------------------
  Purpose:
  Notes:
@@ -1084,11 +1098,9 @@ PROCEDURE ipAuditSysCtrl:
         .
                 
 END PROCEDURE.
-	
+
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
-
-
 
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipBackupDataFiles C-Win 
 PROCEDURE ipBackupDataFiles :
@@ -1219,6 +1231,7 @@ PROCEDURE ipBackupDBs :
     DEF VAR cThisPort AS CHAR NO-UNDO.
     
     ASSIGN 
+        lSuccess = FALSE 
         iCount = 1.
         
     DO iCount = 1 TO 2:
@@ -1282,6 +1295,8 @@ PROCEDURE ipBackupDBs :
         IF SEARCH(cBackupName) NE ? THEN 
         DO:
             ASSIGN
+                iopiStatus = iopiStatus + 5
+                rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75)
                 lSuccess = TRUE.
             RUN ipStatus ("    Backup successful").
         END.
@@ -1290,8 +1305,12 @@ PROCEDURE ipBackupDBs :
             ASSIGN
                 lSuccess = FALSE.
             RUN ipStatus ("    Backup FAILED").
+            RETURN.
         END.
     END.
+    
+    ASSIGN 
+        lSuccess = TRUE.
     
 END PROCEDURE.
 
@@ -1936,6 +1955,9 @@ PROCEDURE ipCopyRelNotes :
 
     DEF VAR cCommandLine AS CHAR NO-UNDO.
     
+    ASSIGN 
+        lSuccess = FALSE.
+    
     FILE-INFO:FILE-NAME = cDocDir.
     IF FILE-INFO:FULL-PATHNAME EQ ? THEN
         OS-CREATE-DIR VALUE(cDocDir).
@@ -1944,6 +1966,9 @@ PROCEDURE ipCopyRelNotes :
     ASSIGN
         cCommandLine = "COPY " + cUpdRelNotesDir + "\*.* " + cDocDir + "\ReleaseNotes".
     OS-COMMAND SILENT VALUE(cCommandLine).
+    
+    ASSIGN 
+        lSuccess = TRUE.
     
 END PROCEDURE.
 
@@ -2045,7 +2070,8 @@ PROCEDURE ipDataFix :
     RUN ipStatus ("Starting Data Fixes - from version " + fiFromVer:{&SV}).
 
     ASSIGN 
-        cThisEntry = fiFromVer:{&SV}.
+        cThisEntry = fiFromVer:{&SV}
+        lSuccess = FALSE.
 
     IF fIntVer(cThisEntry) LT 16001000 THEN
         RUN ipDataFix160001.
@@ -2081,6 +2107,9 @@ PROCEDURE ipDataFix :
         RUN ipDataFix160899.
 
     RUN ipStatus ("Completed Data Fixes").
+    
+    ASSIGN 
+        lSuccess = TRUE.
 
 END PROCEDURE.
 
@@ -2374,9 +2403,8 @@ END PROCEDURE.
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
 
-
-&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipDataFix160860 C-Win
-PROCEDURE ipDataFix160860:
+&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipDataFix160860 C-Win 
+PROCEDURE ipDataFix160860 :
 /*------------------------------------------------------------------------------
  Purpose:
  Notes:
@@ -2385,15 +2413,12 @@ PROCEDURE ipDataFix160860:
 
         
 END PROCEDURE.
-	
+
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
 
-
-
-
-&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipDataFix160880 C-Win
-PROCEDURE ipDataFix160880:
+&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipDataFix160880 C-Win 
+PROCEDURE ipDataFix160880 :
 /*------------------------------------------------------------------------------
  Purpose:
  Notes:
@@ -2404,11 +2429,9 @@ PROCEDURE ipDataFix160880:
 /*    RUN ipUpdateAdvantzwarePf.*/
 
 END PROCEDURE.
-	
+
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
-
-
 
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipDataFix160899 C-Win 
 PROCEDURE ipDataFix160899 :
@@ -2464,6 +2487,9 @@ PROCEDURE ipDelBadData :
 ------------------------------------------------------------------------------*/
     RUN ipStatus ("Removing Deprecated File Entries").
 
+    ASSIGN 
+        lSuccess = FALSE.
+
     DISABLE TRIGGERS FOR LOAD OF parmfile.
     DISABLE TRIGGERS FOR LOAD OF userlog.
     DISABLE TRIGGERS FOR LOAD OF mfdata.
@@ -2483,6 +2509,9 @@ PROCEDURE ipDelBadData :
     IF lNeedUsercontrol THEN FOR EACH userlog:
         DELETE userlog.
     END.
+
+    ASSIGN 
+        lSuccess = TRUE.
 
 END PROCEDURE.
 
@@ -2612,9 +2641,8 @@ END PROCEDURE.
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
 
-
-&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipDeleteAudit C-Win
-PROCEDURE ipDeleteAudit:
+&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipDeleteAudit C-Win 
+PROCEDURE ipDeleteAudit :
 /*------------------------------------------------------------------------------
  Purpose:
  Notes:
@@ -2642,11 +2670,9 @@ PROCEDURE ipDeleteAudit:
     END.
 
 END PROCEDURE.
-	
+
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
-
-
 
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipExpandFiles C-Win 
 PROCEDURE ipExpandFiles :
@@ -2670,6 +2696,7 @@ PROCEDURE ipExpandFiles :
     RUN ipStatus ("Installing New ASI System Files").
 
     ASSIGN 
+        lSuccess = FALSE 
         cThisEntry = fiEnvironment:{&SV}
         cTgtEnv = cEnvDir + "\" + fiEnvironment:{&SV}.
 
@@ -2712,6 +2739,9 @@ PROCEDURE ipExpandFiles :
 
     RUN ipStatus ("Installation of new system files complete").
     
+    ASSIGN 
+        lSuccess = TRUE.
+
 END PROCEDURE.
 
 /* _UIB-CODE-BLOCK-END */
@@ -2824,9 +2854,6 @@ END PROCEDURE.
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
 
-
-
-
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipFixPoEdiDirs C-Win 
 PROCEDURE ipFixPoEdiDirs :
 /*------------------------------------------------------------------------------
@@ -2898,6 +2925,9 @@ PROCEDURE ipFixUsers :
 ------------------------------------------------------------------------------*/
     RUN ipStatus ("Validating Required Users").
 
+    ASSIGN 
+        lSuccess = FALSE.
+        
     IF NOT CAN-FIND (FIRST users WHERE
                      users.user_id = "asi") THEN
         RUN ipCreateAsiUser IN THIS-PROCEDURE.
@@ -2912,6 +2942,9 @@ PROCEDURE ipFixUsers :
 
     RUN ipLoadNewUserData IN THIS-PROCEDURE.
     RUN ipCleanBadUserData IN THIS-PROCEDURE.
+    
+    ASSIGN 
+        lSuccess = TRUE.
 
 END PROCEDURE.
 
@@ -3196,9 +3229,8 @@ END PROCEDURE.
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
 
-
-&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipLoadJasperData C-Win
-PROCEDURE ipLoadJasperData:
+&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipLoadJasperData C-Win 
+PROCEDURE ipLoadJasperData :
 /*------------------------------------------------------------------------------
  Purpose:
  Notes:
@@ -3213,6 +3245,7 @@ PROCEDURE ipLoadJasperData:
     DISABLE TRIGGERS FOR LOAD OF dynParam.
     DISABLE TRIGGERS FOR LOAD OF dynParamSet.
     DISABLE TRIGGERS FOR LOAD OF dynParamValue.
+    DISABLE TRIGGERS FOR LOAD OF dynParamSetDtl.
     
     /* Remove all records that we plan to replace */
     FOR EACH dynSubject EXCLUSIVE WHERE 
@@ -3352,11 +3385,9 @@ PROCEDURE ipLoadJasperData:
     INPUT CLOSE.
 
 END PROCEDURE.
-	
+
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
-
-
 
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipLoadLookups C-Win 
 PROCEDURE ipLoadLookups :
@@ -4052,47 +4083,135 @@ PROCEDURE ipProcessAll :
 
     IF tbBackupDBs:CHECKED IN FRAME {&FRAME-NAME} THEN DO:
         RUN ipBackupDBs.
+        IF lSuccess EQ FALSE THEN RETURN. 
     END.
     IF tbUserControl:CHECKED IN FRAME {&FRAME-NAME} THEN DO:
         RUN ipUpdateUserControl.
+        IF lSuccess EQ TRUE THEN ASSIGN 
+            iopiStatus = iopiStatus + 1
+            rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
+        ELSE RETURN.
     END.
+    ELSE ASSIGN 
+        iopiStatus = iopiStatus + 1
+        rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
+    
     IF tbUserCleanup:CHECKED IN FRAME {&FRAME-NAME} THEN DO:
         RUN ipFixUsers.
+        IF lSuccess EQ TRUE THEN ASSIGN 
+            iopiStatus = iopiStatus + 1
+            rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
+        ELSE RETURN.
     END.
+    ELSE ASSIGN 
+        iopiStatus = iopiStatus + 1
+        rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
+
     IF tbDelBadData:CHECKED IN FRAME {&FRAME-NAME} THEN DO:
         RUN ipDelBadData.
+        IF lSuccess EQ TRUE THEN ASSIGN 
+            iopiStatus = iopiStatus + 2
+            rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
+        ELSE RETURN.
     END.
+    ELSE ASSIGN 
+        iopiStatus = iopiStatus + 2
+        rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
+
     IF tbUpdateMaster:CHECKED IN FRAME {&FRAME-NAME} THEN DO:
         RUN ipUpdateMaster.
+        IF lSuccess EQ TRUE THEN ASSIGN 
+            iopiStatus = iopiStatus + 4
+            rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
+        ELSE RETURN.
     END.
+    ELSE ASSIGN 
+        iopiStatus = iopiStatus + 4
+        rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
+
     IF tbRunDataFix:CHECKED IN FRAME {&FRAME-NAME} THEN DO:
         RUN ipDataFix.
+        IF lSuccess EQ TRUE THEN ASSIGN 
+            iopiStatus = iopiStatus + 10
+            rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
+        ELSE RETURN.
     END.
+    ELSE ASSIGN 
+        iopiStatus = iopiStatus + 10
+        rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
+
     IF tbUpdateNK1s:CHECKED IN FRAME {&FRAME-NAME} THEN DO:
         RUN ipUpdateNK1s.
-        /* RUN ipVerifyNK1Changes. */
+        IF lSuccess EQ TRUE THEN ASSIGN 
+            iopiStatus = iopiStatus + 3
+            rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
+        ELSE RETURN.
     END.
+    ELSE ASSIGN 
+        iopiStatus = iopiStatus + 3
+        rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
+
     IF tbLoadMenus:CHECKED IN FRAME {&FRAME-NAME} THEN DO:
         /* Deprecated in 16.8.5 
         RUN ipLoadMenus (cUpdMenuDir,cEnvProdDir).
         */
     END.
+
     IF tbRelNotes:CHECKED IN FRAME {&FRAME-NAME} THEN DO:
         RUN ipCopyRelNotes.
+        IF lSuccess EQ TRUE THEN ASSIGN 
+            iopiStatus = iopiStatus + 2
+            rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
+        ELSE RETURN.
     END.
+    ELSE ASSIGN 
+        iopiStatus = iopiStatus + 2
+        rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
+
     IF tbBackupFiles:CHECKED IN FRAME {&FRAME-NAME} THEN DO:
         RUN ipArchiveFiles.
+        IF lSuccess EQ TRUE THEN ASSIGN 
+            iopiStatus = iopiStatus + 10
+            rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
+        ELSE RETURN.
     END.
+    ELSE ASSIGN 
+        iopiStatus = iopiStatus + 10
+        rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
+    
     IF tbInstallFiles:CHECKED IN FRAME {&FRAME-NAME} THEN DO:
         RUN ipExpandFiles.
+        IF lSuccess EQ TRUE THEN ASSIGN 
+            iopiStatus = iopiStatus + 20
+            rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
+        ELSE RETURN.
     END.
+    ELSE ASSIGN 
+        iopiStatus = iopiStatus + 20
+        rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
+
     IF tbRefTableConv:CHECKED IN FRAME {&FRAME-NAME} THEN DO:
         RUN ipRefTableConv.
+        IF lSuccess EQ TRUE THEN ASSIGN 
+            iopiStatus = iopiStatus + 30
+            rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
+        ELSE RETURN.
     END.
+    ELSE ASSIGN 
+        iopiStatus = iopiStatus + 30
+        rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
+    
     IF tbUpdateIni:CHECKED IN FRAME {&FRAME-NAME} THEN DO:
         RUN ipUpdateTTIniFile.
         RUN ipWriteIniFile.
+        IF lSuccess EQ TRUE THEN ASSIGN 
+            iopiStatus = iopiStatus + 5
+            rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
+        ELSE RETURN.
     END.
+    ELSE ASSIGN 
+        iopiStatus = iopiStatus + 5
+        rStatusBar:WIDTH = MIN(75,(iopiStatus / 100) * 75).
     
     RUN ipStatus ("Patch Application Complete").
 
@@ -4124,6 +4243,7 @@ PROCEDURE ipRefTableConv :
     RUN ipStatus ("Converting Reftable records...").
 
     ASSIGN
+        lSuccess = FALSE 
         cOrigPropath = PROPATH
         cNewPropath  = cEnvDir + "\" + fiEnvironment:{&SV} + "\Programs," + PROPATH
         PROPATH = cNewPropath.
@@ -4193,6 +4313,9 @@ PROCEDURE ipRefTableConv :
             END.
         END.   
     END.  /*FOR EACH reftable1*/  
+
+    ASSIGN 
+        lSuccess = TRUE.
 
 END PROCEDURE.
 
@@ -4660,9 +4783,8 @@ END PROCEDURE.
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
 
-
-&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipUpdateAdvantzwarePf C-Win
-PROCEDURE ipUpdateAdvantzwarePf:
+&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipUpdateAdvantzwarePf C-Win 
+PROCEDURE ipUpdateAdvantzwarePf :
 /*------------------------------------------------------------------------------
  Purpose: This is broken, but is superseded by copying advantzware.pf during startUpdate
  Notes:
@@ -4705,11 +4827,9 @@ PROCEDURE ipUpdateAdvantzwarePf:
     OUTPUT CLOSE.
     
 END PROCEDURE.
-	
+
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
-
-
 
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipUpdateMaster C-Win 
 PROCEDURE ipUpdateMaster :
@@ -4719,6 +4839,9 @@ PROCEDURE ipUpdateMaster :
   Notes:       
 ------------------------------------------------------------------------------*/
     RUN ipStatus ("Updating Master Records").
+
+    ASSIGN 
+        lSuccess = FALSE.
 
     RUN ipBackupDataFiles IN THIS-PROCEDURE.
     
@@ -4747,6 +4870,9 @@ PROCEDURE ipUpdateMaster :
     IF SEARCH(cUpdDataDir + "\cuecardtext.d") <> ? THEN
         RUN ipLoadCueCardText IN THIS-PROCEDURE.
 
+    ASSIGN 
+        lSuccess = TRUE.
+
 END PROCEDURE.
 
 /* _UIB-CODE-BLOCK-END */
@@ -4765,6 +4891,9 @@ PROCEDURE ipUpdateNK1s :
         
     RUN ipStatus ("Updating NK1 Records").
     
+    ASSIGN 
+        lSuccess = FALSE.
+
     DISABLE TRIGGERS FOR LOAD OF sys-ctrl.
     DISABLE TRIGGERS FOR LOAD OF sys-ctrl-shipto.
     DISABLE TRIGGERS FOR DUMP OF sys-ctrl.
@@ -4810,7 +4939,7 @@ PROCEDURE ipUpdateNK1s :
             sys-ctrl.log-fld = TRUE.
     END.
     
-	/* Upgrade Button */
+        /* Upgrade Button */
     RUN ipStatus ("  MenuLinkUpdate").
     FOR EACH  sys-ctrl WHERE
         sys-ctrl.name EQ "MenuLinkUpgrade":
@@ -4864,6 +4993,8 @@ PROCEDURE ipUpdateNK1s :
             sys-ctrl.securityLevelUser = 1000.
     END.
     
+    ASSIGN 
+        lSuccess = TRUE.
        
 END PROCEDURE.
 
@@ -4879,6 +5010,7 @@ PROCEDURE ipUpdateTTIniFile :
     ------------------------------------------------------------------------------*/
 
     ASSIGN 
+        lSuccess = FALSE 
         iListEntry = LOOKUP(fiEnvironment:{&SV},cEnvList).    
 
     FIND ttIniFile WHERE ttIniFile.cVarName = "envVerList" NO-ERROR.
@@ -4901,6 +5033,7 @@ PROCEDURE ipUpdateUserControl :
     DISABLE TRIGGERS FOR LOAD OF usercontrol.
     
     ASSIGN
+        lSuccess = FALSE 
         iUserCount = INTEGER(fiLicensedUsers:{&SV}).
         
     /* Create/update usercontrol record */
@@ -4939,6 +5072,8 @@ PROCEDURE ipUpdateUserControl :
     END.
     
     RELEASE usercontrol.
+    ASSIGN 
+        lSuccess = TRUE.
     
 END PROCEDURE.
 
@@ -5092,6 +5227,10 @@ PROCEDURE ipWriteIniFile :
         ELSE NEXT.
     END.
     OUTPUT CLOSE.
+    
+    ASSIGN 
+        lSuccess = TRUE.
+    
 END PROCEDURE.
 
 /* _UIB-CODE-BLOCK-END */
@@ -5125,9 +5264,8 @@ END FUNCTION.
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
 
-
-&ANALYZE-SUSPEND _UIB-CODE-BLOCK _FUNCTION fIntVer C-Win
-FUNCTION fIntVer RETURNS INTEGER 
+&ANALYZE-SUSPEND _UIB-CODE-BLOCK _FUNCTION fIntVer C-Win 
+FUNCTION fIntVer RETURNS INTEGER
   ( INPUT cVerString AS CHAR ):
     /*------------------------------------------------------------------------------
       Purpose:  Converts a version string like "16.4.8" or "16.7.12.2" to an integer
@@ -5153,9 +5291,7 @@ FUNCTION fIntVer RETURNS INTEGER
     RETURN iIntVer.   /* Function return value. */
 
 END FUNCTION.
-	
+
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
-
-
 

--- a/Template/BuildScript/compile.p
+++ b/Template/BuildScript/compile.p
@@ -1,16 +1,95 @@
+/*------------------------------------------------------------------------
+  File:                 asiInstaller.w
+  Description:          utility to create files for patch distribution
+  Input Parameters:     (none)
+  Output Parameters:    (none)
+  Author:               MYT
+  Created:              04/05/19
+  Change History:
+------------------------------------------------------------------------*/
 &SCOPED-DEFINE cDir N:\Repositories\Advantzware
 &SCOPED-DEFINE cTarget N:\Repositories\Advantzware\Template\Patch\Admin\EnvAdmin
+
+DEF VAR cConnectDb AS CHAR NO-UNDO.
+DEF VAR cConnectAud AS CHAR NO-UNDO.
+DEF VAR cDbName AS CHAR NO-UNDO FORMAT "x(11)" LABEL "  Enter the DB name for compile".
+DEF VAR cAudName AS CHAR NO-UNDO.
+DEF VAR cRaw AS CHAR NO-UNDO.
+DEF VAR cDbList AS CHAR NO-UNDO FORMAT "x(100)" LABEL "  Choices".
+DEF VAR cAudDbList AS CHAR NO-UNDO.
+DEF VAR iIndex AS INT NO-UNDO.
+DEF VAR iCtr AS INT NO-UNDO.
+DEF VAR cDir AS CHAR NO-UNDO.
+DEF VAR cTarget AS CHAR NO-UNDO.
+
 ASSIGN 
-    propath = "{&cDir}\Template\BuildScript\ToCompile,{&cDir}\Legacy,{&cDir}\Resources," + propath.
+    FILE-INFO:FILE-NAME = "N:\Repositories\Advantzware".
+IF FILE-INFO:FULL-PATHNAME EQ ? THEN DO:
+    ASSIGN 
+        FILE-INFO:FILE-NAME = "N:\Repository".
+    IF FILE-INFO:FULL-PATHNAME EQ ? THEN DO:
+        MESSAGE 
+            "Unable to locate a source or target directory.  Quitting."
+            VIEW-AS ALERT-BOX.
+        QUIT.
+    END.
+END.
 
-COMPILE {&cDir}\Template\BuildScript\ToCOMPILE\asiLogin.w SAVE INTO {&cTarget}.
-COMPILE {&cDir}\Template\BuildScript\ToCOMPILE\asiUpdate.w SAVE INTO {&cTarget}.
-COMPILE {&cDir}\Template\BuildScript\ToCOMPILE\asiUpdateDb.w SAVE INTO {&cTarget}.
+ASSIGN 
+    cDir = FILE-INFO:FULL-PATHNAME
+    cTarget = cDir + "\Template\Patch\Admin\EnvAdmin".
 
-CONNECT -db asiDevel -H localhost -S 2821 -ld asi.
-COMPILE {&cDir}\Template\BuildScript\ToCOMPILE\prerun.p SAVE INTO {&cTarget}.
 
-CONNECT -db audDevel -H localhost -S 2831 -ld audit.
-COMPILE {&cDir}\Template\BuildScript\ToCOMPILE\asiUpdateEnv.w SAVE INTO {&cTarget}.
+INPUT FROM os-dir ("c:\asigui\databases\compile").
+REPEAT:
+    IMPORT cRaw.
+    IF cRaw BEGINS "asi"
+    AND INDEX(cRaw,".lg") NE 0 THEN ASSIGN 
+        cDbList = cDbList + REPLACE(cRaw,".lg","") + ",".
+    ELSE IF cRaw BEGINS "aud"
+    AND INDEX(cRaw,".lg") NE 0 THEN ASSIGN 
+        cAudDbList = cAudDbList + REPLACE(cRaw,".lg","") + ",".
+END.
+INPUT CLOSE.
+ASSIGN 
+    cDbList = TRIM(cDbList,",")
+    cAudDbList = TRIM(cAudDbList,",").
 
-RUN {&cDir}\Template\BuildScript\buildDumpFiles.p.
+DISP 
+    cDBname SKIP 
+    cDbList 
+    WITH FRAME a TITLE "DB Selection"
+    VIEW-AS DIALOG-BOX THREE-D SIDE-LABELS WIDTH 120.
+
+UPDATE 
+    cDBname 
+    WITH FRAME a.
+    
+DO iCtr = 1 TO NUM-ENTRIES(cDbList):
+    IF cDbName EQ ENTRY(iCtr,cDbList) THEN ASSIGN 
+        iIndex = iCtr.    
+END.
+
+IF iIndex = 0 THEN DO:
+    MESSAGE 
+        "You entered an invalid DB Name.  Quitting"
+        VIEW-AS ALERT-BOX.
+    QUIT.
+END. 
+ELSE ASSIGN 
+    cConnectDb = "-db c:\asigui\databases\compile\" + cDbName + " -1 -ld ASI"
+    cConnectAud = "-db c:\asigui\databases\compile\aud" + SUBSTRING(cDbName,4) + " -1 -ld Audit"
+    propath = cDir + "\Template\BuildScript\ToCompile," + cDir + "\Legacy," + cDir + "\Resources," + propath
+    .
+
+COMPILE VALUE(cDir + "\Template\BuildScript\ToCompile\asiLogin.w") SAVE INTO value(cTarget).
+COMPILE VALUE(cDir + "\Template\BuildScript\ToCompile\asiUpdate.w") SAVE INTO value(cTarget).
+COMPILE VALUE(cDir + "\Template\BuildScript\ToCompile\asiUpdateDb.w") SAVE INTO value(cTarget).
+
+CONNECT VALUE(cConnectDb).
+COMPILE VALUE(cDir + "\Template\BuildScript\ToCompile\prerun.p") SAVE INTO value(cTarget).
+
+CONNECT VALUE(cConnectAud).
+COMPILE VALUE(cDir + "\Template\BuildScript\ToCompile\asiUpdateEnv.w") SAVE INTO value(cTarget).
+
+

--- a/Template/Patch/Admin/EnvAdmin/EmptyFolder.bat
+++ b/Template/Patch/Admin/EnvAdmin/EmptyFolder.bat
@@ -1,0 +1,6 @@
+@ECHO OFF
+:: Remove all programs from /Updates dir
+RD /S /Q ..\..\Updates > NUL
+MKDIR ..\..\Updates
+EXIT
+

--- a/Template/Patch/xinstUpdate.bat
+++ b/Template/Patch/xinstUpdate.bat
@@ -1,10 +1,35 @@
-@ECHO OFF
+@ECHO ON
 SET iniFile=..\Admin\advantzware.ini
 SET tgtDir=..\Admin\EnvAdmin
 
 :: Read advantzware.ini and set variable values
 FOR /F "tokens=1,2 delims==" %%G IN (%iniFile%) DO SET %%G=%%H
 SETLOCAL ENABLEDELAYEDEXPANSION
+
+:: Check to ensure we're NOT in the upgrade dir
+IF EXIST "..\..\DoNotDelete.txt" (
+    ECHO MSGBOX "DON'T RUN THIS FROM AWS /UPGRADES!!!" > %temp%\TEMPmessage.vbs
+    CALL %temp%\TEMPmessage.vbs
+    DEL %temp%\TEMPmessage.vbs /f /q
+    GOTO :QUIT
+    )
+
+:: Check to ensure we're on the ASI server
+IF NOT !Hostname! == %computername% (
+    ECHO MSGBOX "You MUST run this program on the ASI server." > %temp%\TEMPmessage.vbs
+    CALL %temp%\TEMPmessage.vbs
+    DEL %temp%\TEMPmessage.vbs /f /q
+    GOTO :QUIT
+    )
+
+:: Check to ensure the user has Admiin rights
+NET SESSION >nul 2>&1
+IF NOT %errorlevel%==0 (
+    ECHO MSGBOX "You MUST run this program as an Administrator." > %temp%\TEMPmessage.vbs
+    CALL %temp%\TEMPmessage.vbs
+    DEL %temp%\TEMPmessage.vbs /f /q
+    GOTO :QUIT
+    )
 
 :: Move to Admin/EnvAdmin dir
 CD ..\Admin\Envadmin
@@ -22,8 +47,8 @@ DEL /Q *2.txt > NUL
 DEL /Q *3.txt > NUL
 DEL /Q 7z.* > NUL
 DEL /Q convusr.* > NUL
-DEL /Q prerun*.* > NUL
 CLS
+
 :: Move to Updates dir
 CD ..\..\Updates
 
@@ -44,15 +69,20 @@ IF EXIST "!DLCDir!\progress.run" (
     COPY /Y !DLCDir!\progress.cfg .\progress.cfg > NUL
     COPY /Y .\Structure\STFiles\progress.dev !DLCDir!\progress.cfg > NUL
 )
+CACLS !DLCDir!\progress.cfg /e /p Everyone:f
 
 :: Now move into envadmin and run the update program(s)
 CD ..\Admin\Envadmin
+
 CALL !DLCDir!\bin\prowin.exe -basekey INI -ininame dbms.ini -pf advantzware.pf -p asiUpdate.w  
 
 :: Switch progress.cfg back to .run version
+
 CD ..\..\Updates
-XCOPY /Y !DLCDir!\progress.cfg !DLCDir!\progress.dev > NUL
-XCOPY /Y .\progress.cfg !DLCDir!\progress.cfg > NUL
+
+COPY /Y !DLCDir!\progress.cfg !DLCDir!\progress.dev > NUL
+COPY /Y .\progress.cfg !DLCDir!\progress.cfg > NUL
+CACLS !DLCDir!\progress.cfg /e /p Everyone:f
 
 :: Concatenate the extended and current update logs
 COPY /Y ..\Admin\EnvAdmin\UpdateHist.txt+..\Admin\EnvAdmin\UpdateLog.txt ..\Admin\EnvAdmin\UpdateHist1.txt > NUL
@@ -63,13 +93,14 @@ CLS
 
 :: Delete any unused/deprecated programs from dir structure
 cd ..\Desktop
-IF EXIST "ASI Update".* (
+
+IF EXIST "ASI Update" (
     DEL /S /Q "ASI Update"* > NUL
 )
-:: Remove all programs from /Updates dir
-cd ..\Updates
-RD /S /Q . > NUL
-DEL /S /Q *.* > NUL
 
-QUIT
+:QUIT
+CD ..\Admin\EnvAdmin
+EmptyFolder.bat
+
+EXIT
 


### PR DESCRIPTION
Programs added/changed:
(these may be described in other comments as well)
Template/BuildScript/
compile.p - made interactive, so can choose which COMPILE database to use
Template/BuildScript/ToCompile:
asiLogin - modified initial dir from "N:" to relative - since Premier will find "N:" (Production) first
asiUpdate - added Clay's progress bar
                    - added Success/Fail message on completion
                    - modified initial dir from "N:" to relative - since Premier will find "N:" (Production) first
                    - fixed FTP send to AWS (now using WinSCP) so should work for all customers
                    - assign position to be fixed, so all update windows take the same position/size
asiUpdateDB.w - added Clay's progress bar
                             - assign position to be fixed, so all update windows take the same position/size
asiUpdateENV.w - added Clay's progress bar
                                - fixed window width to match other update pgms
                                - assign position to be fixed, so all update windows take the same position/size
                                - if any procedure fails, will exit back to calling pgm
                               - added missing DISABLE TRIGGERS statement to Jasper file load
Template/Patch/Admin/EnvAdmin
EmptyFolder.bat - added program to Delete /Updates directory from outside calling program
Template/Patcvh:
xinstUpdate.txt - Turned on ECHO so can monitor any errors that may occur
                            - added tests for "server run on", "user's admin rights", "running on AWS by accident"
                            - removed deletion of "prerun.r" file; may be required for multi-version customers
                            - added permissions settings for progress.cfg to prevent copy failures
                            - added call to EmptyFolder.bat to prevent "hanging" cmd prompt