### PR TITLE
47758 Touchscreen

### DIFF
--- a/Template/BuildScript/ToCompile/asiLogin.w
+++ b/Template/BuildScript/ToCompile/asiLogin.w
@@ -204,6 +204,10 @@ END.
 RUN ipFindIniFile ("..\advantzware.ini",
                    OUTPUT cIniLoc).
 
+ASSIGN 
+    FILE-INFO:FILE-NAME = cIniLoc
+    cIniLoc = FILE-INFO:FULL-PATHNAME.
+
 IF cIniLoc EQ "" THEN DO:
     MESSAGE
         "Unable to locate an 'advantzware.ini' file." SKIP
@@ -226,6 +230,10 @@ END.
 /* Find the .usr file containing user-level settings */
 RUN ipFindIniFile ("N:\Admin\advantzware.usr",
                    OUTPUT cUsrLoc).
+ASSIGN 
+    FILE-INFO:FILE-NAME = cUsrLoc
+    cUsrLoc = FILE-INFO:FULL-PATHNAME.
+
 IF cUsrLoc EQ "" THEN DO:
     MESSAGE
         "Unable to locate an 'advantzware.usr' file." SKIP
@@ -747,14 +755,16 @@ PROCEDURE ipChangeEnvironment :
     DEF VAR iLookup AS INT NO-UNDO.
     DEF VAR iCtr AS INT NO-UNDO.
     DEF VAR cTestList AS CHAR NO-UNDO.
+    DEF VAR iDbLevelM AS INT NO-UNDO.
+    DEF VAR iEnvLevelM AS INT NO-UNDO.
     
     ASSIGN
         iPos = LOOKUP(cbEnvironment,cEnvironmentList)
         iEnvLevel = intVer(ENTRY(iPos,cEnvVerList))
         iPos = LOOKUP(cbDatabase,cDatabaseList)
         iDbLevel = intVer(ENTRY(iPos,cDbVerList))
+        iEnvLevelM = iEnvLevel / 1000
         .
-    /* Here the format for both is 16070400 */
 
     if cSessionParam gt "" then do:
       cbDatabase = ENTRY(1,cDatabaseList).
@@ -773,7 +783,7 @@ PROCEDURE ipChangeEnvironment :
                      cTop + cEnvResourceDir + "\Addon" + "," +
                      cMapDir + "\" + cAdminDir + "\" + cEnvAdmin + ",".
         PROPATH = preProPath + origPropath.      
-      return.
+        RETURN.
     end.
     
     CASE cbEnvironment:SCREEN-VALUE IN FRAME {&FRAME-NAME}:
@@ -800,11 +810,18 @@ PROCEDURE ipChangeEnvironment :
                 cTestList = "".
             DO iCtr = 1 TO NUM-ENTRIES(cDbList):
                 ASSIGN 
-                    iDbLevel = intVer(ENTRY(iCtr,cDbVerList)).
-                IF iEnvLevel LT iDbLevel THEN NEXT.
-                IF iEnvLevel GT iDbLevel + 10000 THEN NEXT.
-                IF iEnvLevel GE iDbLevel + 1000 
-                AND CAN-DO(cDBVerList,STRING(iDbLevel + 1000)) THEN NEXT.
+                    iEnvLevelM = iEnvLevel / 1000
+                    iDbLevelM = intVer(ENTRY(iCtr,cDbVerList)) / 1000.
+                if iEnvLevelM GT 16085 THEN DO:
+                    IF iEnvLevelM LT iDbLevelM THEN NEXT.
+                    IF iEnvLevelM GT iDbLevelM THEN NEXT.
+                END.
+                ELSE DO:
+                    ASSIGN
+                        iEnvLevelM = 10 * TRUNCATE(iEnvLevelM / 10,0).        
+                    IF iEnvLevelM LT iDbLevelM THEN NEXT.
+                    IF iEnvLevelM GT iDbLevelM THEN NEXT.
+                END.
                 ASSIGN 
                     cTestList = cTestList + ENTRY(iCtr,cDbList) + ",".    
             END.


### PR DESCRIPTION
File changed: /template/buildScript/ToCompile/asiLogin.w
This issue was introduced with the latest version of asiLogin, when locating the advantzware.ini file.  The location routine uses the "current directory" (which when run is usually N:\admin\envadmin).  The locator attempts to find the advantzware.ini file, and is successful, recording that location as "..\advantzware.ini" - that is, one directory UP from where I am now.  Later, after the user has chosen his selected environment, the current directory is moved to the environment (for example, N:\Environments\Prod).  This makes the reference to "one up from where I am now" equivalent to N:\Environments.  Since the file is not in that location, the lookup in viewers/user.w fails, and the selection lists all display as blanks.
Specs:
The solution is to modify the asiLogin program to assign the cIniLoc variable to be the full pathname of the advantzware.ini file: N:\admin\advantzware.ini.  Testing on AWS and local env show that this resolves the problem.

Test Case:
Run advantzware, select any environment and database
Open N-U-3.
Open any user record.
Success if the 3 selection lists on the right side are populated.

Other changes in this file (related to DbLevelM variables) are for internal use, and support the limitation of database choices to match the environment chosen