### PR TITLE
48019 the AR Line date should be set to Inv.date upon creation

### DIFF
--- a/Legacy/ar/d-arinvl.w
+++ b/Legacy/ar/d-arinvl.w
@@ -1052,6 +1052,7 @@ PROCEDURE create-item :
             ar-invl.sman[1] = IF AVAIL cust THEN cust.sman ELSE ""
             ar-invl.s-pct[1] = IF ar-invl.sman[1] NE "" THEN 100 ELSE 0
             ar-invl.actnum =  ar-ctrl.sales
+            ar-invl.inv-date = ar-inv.inv-date
                 .
 
          FIND FIRST account WHERE account.company = g_company

--- a/Legacy/ar/r-fince.w
+++ b/Legacy/ar/r-fince.w
@@ -581,7 +581,8 @@ PROCEDURE bill-finance :
        ar-invl.unit-pr    = ar-inv.net
        ar-invl.pr-qty-uom = "EA"
        ar-invl.amt        = ar-inv.net
-       ar-invl.actnum     = ar-ctrl.onac.
+       ar-invl.actnum     = ar-ctrl.onac
+       ar-invl.inv-date   = ar-inv.inv-date.
 
     end.
   END.

--- a/Legacy/oe/invlpost.i
+++ b/Legacy/oe/invlpost.i
@@ -82,6 +82,7 @@ assign
  ar-invl.loc          = IF AVAIL oe-boll THEN oe-boll.loc ELSE ""
  ar-invl.lot-no       = inv-line.lot-no
  ar-invl.e-num        = inv-line.e-num
+ ar-invl.inv-date   = inv-head.inv-date
  .
 
  

--- a/Legacy/util/ImportAR.p
+++ b/Legacy/util/ImportAR.p
@@ -567,7 +567,8 @@ PROCEDURE pCreateNewInvoiceLineAR:
         ar-invl.dscr[1]    = "M"
         ar-invl.actnum     = IF AVAILABLE ar-ctrl THEN ar-ctrl.sales ELSE ""
         ar-invl.sman[1]    = IF AVAILABLE cust THEN cust.sman ELSE ""
-        ar-invl.s-pct[1]   = IF ar-invl.sman[1] NE "" THEN 100 ELSE 0             
+        ar-invl.s-pct[1]   = IF ar-invl.sman[1] NE "" THEN 100 ELSE 0    
+        ar-invl.inv-date   = ar-inv.inv-date         
         .
     opriARInvl = ROWID(ar-invl).
     RELEASE ar-invl.

--- a/Legacy/util/ar-inv-repair.p
+++ b/Legacy/util/ar-inv-repair.p
@@ -341,7 +341,8 @@ PROCEDURE CREATE-ar-invl.
                ar-invl.std-lab-cost = itemfg.std-lab-cost
                ar-invl.std-fix-cost = itemfg.std-fix-cost
                ar-invl.std-var-cost = itemfg.std-var-cost 
-               ar-invl.std-mat-cost = itemfg.std-mat-cost.
+               ar-invl.std-mat-cost = itemfg.std-mat-cost
+               ar-invl.inv-date     = inv-head.inv-date.
 
                if ar-invl.ord-no eq 0 then ar-invl.s-pct[1] = 100. 
 
@@ -675,7 +676,8 @@ PROCEDURE create-misc-charges.
              ar-invl.misc           = YES
              ar-invl.billable       = IF inv-misc.bill EQ "I" THEN TRUE
                                       ELSE FALSE
-             ar-invl.posted         = YES.
+             ar-invl.posted         = YES
+             ar-invl.inv-date       = inv-head.inv-date.
 
              IF NOT ar-invl.billable THEN ar-invl.amt = 0.
               

--- a/Legacy/util/dev/import.p
+++ b/Legacy/util/dev/import.p
@@ -612,7 +612,8 @@ PROCEDURE pCreateNewInvoiceLineAR:
         ar-invl.dscr[1]    = "EA"
         ar-invl.actnum     = IF AVAILABLE ar-ctrl THEN ar-ctrl.sales ELSE ""
         ar-invl.sman[1]    = IF AVAILABLE cust THEN cust.sman ELSE ""
-        ar-invl.s-pct[1]   = IF ar-invl.sman[1] NE "" THEN 100 ELSE 0             
+        ar-invl.s-pct[1]   = IF ar-invl.sman[1] NE "" THEN 100 ELSE 0
+        ar-invl.inv-date   = ar-inv.inv-date            
         .
     opriARInvl = ROWID(ar-invl).
     RELEASE ar-invl.


### PR DESCRIPTION
Programs changed:
ar\d-arinvl.w
ar\r-fince.w
oe\invlpost.i
util\ar-inv-repair.p
util\ImportAR.p
util\dev\import.p
Set ar-invl.inv-date value to equal ar-inv.inv-date or inv-head.inv-date as appropriate.