### PR TITLE
48118 Order Maintenance - Error selecting Items or Release tab

### DIFF
--- a/Legacy/nosweat/persist.p
+++ b/Legacy/nosweat/persist.p
@@ -295,14 +295,16 @@ PROCEDURE Running_Procedures :
          INDEX(progname,"listrqst.") NE 0 THEN
                 DELETE PROCEDURE phandle.
             ELSE DO:
-                ASSIGN 
-                    hWindowHandle = pHandle:CURRENT-WINDOW
-                    cWinTitle = hWindowHandle:TITLE.
                 is-running = YES.
                 RUN Set_Cursor ("").
                 RUN Set-Focus IN phandle NO-ERROR.
-                RUN findWindowA (0, cWinTitle, OUTPUT intHWind). 
-                RUN SetForeGroundWindow (intHWind, OUTPUT rc).
+                IF pHandle:TYPE EQ "Window" THEN DO:
+                    ASSIGN 
+                        hWindowHandle = pHandle:CURRENT-WINDOW
+                        cWinTitle = hWindowHandle:TITLE.
+                    RUN findWindowA (0, cWinTitle, OUTPUT intHWind). 
+                    RUN SetForeGroundWindow (intHWind, OUTPUT rc).
+                END.
             END.
             RETURN.
         END.

--- a/Legacy/oe/b-ordrel.w
+++ b/Legacy/oe/b-ordrel.w
@@ -891,6 +891,7 @@ END.
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _CUSTOM _MAIN-BLOCK B-table-Win 
 
 
+/* ***************************  Main Block  *************************** */
 SESSION:DATA-ENTRY-RETURN = YES.
 {sys/inc/f3help.i}
 {sys/inc/oeinq.i}
@@ -904,9 +905,11 @@ SESSION:DATA-ENTRY-RETURN = YES.
   DISPLAY FI_moveCol WITH FRAME {&FRAME-NAME}.
 
 
- RUN-PROC = "sbo/oerel-recalc-act.p".
-{methods/smartrun.i}
-   lr-rel-lib = phandle.    
+    RUN-PROC = "sbo/oerel-recalc-act.p".
+    IF NOT VALID-HANDLE(lr-rel-lib)  THEN DO:
+       RUN-PROC = "sbo/oerel-recalc-act.p".
+       RUN VALUE(RUN-PROC) PERSISTENT SET lr-rel-lib.
+    END.
 lv-cust-x = "".
 
 
@@ -1568,11 +1571,7 @@ DEF BUFFER b-oe-rel  FOR oe-rel.
           
       IF NOT VALID-HANDLE(lr-rel-lib)  THEN DO:
          RUN-PROC = "sbo/oerel-recalc-act.p".
-
-          lr-rel-lib = phandle. 
-         RUN VALUE(RUN-PROC) PERSISTENT SET phandle.
-         lr-rel-lib = phandle. 
-
+         RUN VALUE(RUN-PROC) PERSISTENT SET lr-rel-lib.
       END.
 
       IF AVAIL tt-report AND AVAIL oe-rel AND VALID-HANDLE(lr-rel-lib) THEN DO:


### PR DESCRIPTION
Programs changed:
nosweat/persist.p - added test for procedure type prior to finding window title
oe/b-ordrel.w -removed call to smartrun.i, which should only be used for window procs