### PR TITLE
48200 Deprecate FGKEEPZEROBIN and RMKEEPZEROBIN

### DIFF
--- a/Legacy/oe/invpost5.i
+++ b/Legacy/oe/invpost5.i
@@ -33,15 +33,12 @@ DEF VAR liShipJobNo2 AS INT NO-UNDO.
 DEF VAR lcShipLoc AS CHAR NO-UNDO.
 DEFINE VARIABLE cRtnChar AS CHARACTER NO-UNDO.
 DEFINE VARIABLE lRecFound AS LOGICAL NO-UNDO.
-DEFINE VARIABLE FgKeepZeroBin-log AS LOGICAL NO-UNDO.
+DEFINE VARIABLE FgKeepZeroBin-log AS LOGICAL NO-UNDO INITIAL TRUE.
 DEF SHARED TEMP-TABLE tt-bolh NO-UNDO LIKE oe-bolh.
 DEF SHARED TEMP-TABLE tt-boll NO-UNDO LIKE oe-boll.
 
-RUN sys/ref/nk1look.p (INPUT cocode, "FGKEEPZEROBIN", "L" /* Logical */, NO /* check by cust */, 
-    INPUT YES /* use cust not vendor */, "" /* cust */, "" /* ship-to*/,
-OUTPUT cRtnChar, OUTPUT lRecFound).
-IF lRecFound THEN
-     FgKeepZeroBin-log = LOGICAL(cRtnChar) NO-ERROR.
+ASSIGN 
+     FgKeepZeroBin-log = TRUE.
      
 FIND tt-boll WHERE RECID(tt-boll) EQ v-recid1.
 FIND {1}     WHERE RECID({1})     EQ v-recid2.

--- a/Legacy/oe/invpost6.i
+++ b/Legacy/oe/invpost6.i
@@ -28,7 +28,7 @@ DEF VAR v-tag      LIKE oe-boll.tag.
 DEF VAR li-stupid  LIKE v-partial NO-UNDO.
 DEFINE VARIABLE cRtnChar          AS CHARACTER NO-UNDO.
 DEFINE VARIABLE lRecFound         AS LOGICAL   NO-UNDO.
-DEFINE VARIABLE FgKeepZeroBin-log AS LOGICAL   NO-UNDO.
+DEFINE VARIABLE FgKeepZeroBin-log AS LOGICAL   NO-UNDO INITIAL TRUE.
 DEFINE VARIABLE rSaveFgBinRow AS ROWID NO-UNDO.
 
 /* For ship only history */
@@ -49,11 +49,8 @@ FIND {1}     WHERE RECID({1})     EQ v-recid2.
 FIND fg-bin  WHERE RECID(fg-bin)  EQ v-recid3 NO-ERROR.
 
 
-RUN sys/ref/nk1look.p (INPUT cocode, "FGKEEPZEROBIN", "L" /* Logical */, NO /* check by cust */, 
-    INPUT YES /* use cust not vendor */, "" /* cust */, "" /* ship-to*/,
-    OUTPUT cRtnChar, OUTPUT lRecFound).
-IF lRecFound THEN
-    FgKeepZeroBin-log = LOGICAL(cRtnChar) NO-ERROR.
+ASSIGN 
+    FgKeepZeroBin-log = TRUE.
 
 FIND FIRST tt-bolh WHERE tt-bolh.b-no EQ tt-boll.b-no NO-LOCK.
 

--- a/Legacy/oe/oe-bolp6.i
+++ b/Legacy/oe/oe-bolp6.i
@@ -5,7 +5,7 @@
 DEF VAR ll-{2}-set-hdr AS LOG NO-UNDO.
 DEF VAR ll-{2}-zero-bin AS LOG NO-UNDO.
 
-ll-{2}-zero-bin = NO.
+ll-{2}-zero-bin = YES.
 ll-{2}-set-hdr = AVAIL oe-ordl AND CAN-FIND(FIRST b-oe-ordl {sys/inc/ordlcomp.i b-oe-ordl oe-ordl}).
 IF NOT AVAIL fg-bin THEN DO:
   ASSIGN

--- a/Legacy/oe/oe-bolp6.i
+++ b/Legacy/oe/oe-bolp6.i
@@ -3,9 +3,7 @@
 /* -------------------------------------------------------------------------- */
 
 DEF VAR ll-{2}-set-hdr AS LOG NO-UNDO.
-DEF VAR ll-{2}-zero-bin AS LOG NO-UNDO.
 
-ll-{2}-zero-bin = YES.
 ll-{2}-set-hdr = AVAIL oe-ordl AND CAN-FIND(FIRST b-oe-ordl {sys/inc/ordlcomp.i b-oe-ordl oe-ordl}).
 IF NOT AVAIL fg-bin THEN DO:
   ASSIGN
@@ -211,7 +209,6 @@ IF v-bol-qty GT 0                              OR
                   AND sys-ctrl.name    EQ "BOLPOST"
                   AND sys-ctrl.log-fld EQ YES) THEN DO:    
     fg-bin.qty = fg-bin.qty - v-bol-qty.
-    ll-{2}-zero-bin = YES.
 
 END.
  

--- a/Legacy/rm/r-rmte&p.w
+++ b/Legacy/rm/r-rmte&p.w
@@ -168,11 +168,8 @@ RUN methods/prgsecur.p
      OUTPUT v-access-close, /* used in template/windows.i  */
      OUTPUT v-access-list). /* list 1's and 0's indicating yes or no to run, create, update, delete */
      
-RUN sys/ref/nk1look.p (INPUT cocode, "RMKEEPZEROBIN", "L" /* Logical */, NO /* check by cust */, 
-    INPUT YES /* use cust not vendor */, "" /* cust */, "" /* ship-to*/,
-    OUTPUT cRtnChar, OUTPUT lRecFound).
-IF lRecFound THEN
-    RmKeepZeroBin-log = LOGICAL(cRtnChar) NO-ERROR.
+ASSIGN 
+    RmKeepZeroBin-log = YES.
 
 RUN sys/ref/nk1look.p (INPUT cocode, "RMTagValidation", "L" /* Logical */, NO /* check by cust */, 
     INPUT YES /* use cust not vendor */, "" /* cust */, "" /* ship-to*/,

--- a/Legacy/sys/inc/create_nk1.p
+++ b/Legacy/sys/inc/create_nk1.p
@@ -27,7 +27,7 @@ v-std-list = "LoadTagSSCC,IR12,OEDateChange,FGRecptPassWord,InvStatus,BOLQtyPopu
            + "FGRecptUnit,OeDateWarn,PREPMASTER,POFarmOutScores,OEQtyPerUnitWarn,APMatTypeExceptions," 
            + "OEJobHold,lmLock,CESAMPLE,DefaultDir,JobHoldReason,ASIHelpService,CRMAuthToken,TSAMPMWarn,SSScanVendor," 
            + "OEBOLPrompt,SHTCALCWarn,BOLFMTTran,BOLMaster,SalesBudget,CEMarkupMatrixInterpolate,CEMarkupMatrixLookup,"
-           + "KiwiT,BusinessFormModal,LoadTagXprintImage,CEGotoCalc,FGKEEPZEROBIN,RMKEEPZEROBIN,PrePressHotFolderIn,"
+           + "KiwiT,BusinessFormModal,LoadTagXprintImage,CEGotoCalc,PrePressHotFolderIn,"
            + "PrePressHotFolderOut,METRIC,CEImportForm,CEImportFormFolder,BusinessFormLogo,CalcBtnImage,CalcBtnLink,DCClosedJobs,"
            + "ImportFolder,ImportLog,TagFormat,FgItemHideCalcFields,VendCostMatrix,RelSkipRecalc,RMAllowAdd,CECostSave,RMOverrunCostProtection,"
            + "SSBOLPassword,BOLImageFooter,InvAddDate,POFGDims,OEPriceHold,POConfigDir,EDILogs,AutoLogout,AutoLogoutLocal,RMTagValidation,"
@@ -290,16 +290,6 @@ CASE ip-nk1-value:
                            INPUT "" /* Char Value */, INPUT 0 /* Int value */,
                            INPUT NO /* Logical value */, INPUT 0 /* dec value*/).
 
-    WHEN "FGKEEPZEROBIN" THEN 
-    RUN sys/inc/addnk1.p (INPUT cocode, INPUT ip-nk1-value, INPUT NO /* Prompt? */,
-                           INPUT "Keep zero FG bins?",
-                           INPUT "" /* Char Value */, INPUT 0 /* Int value */,
-                           INPUT NO /* Logical value */, INPUT 0 /* dec value*/).
-    WHEN "RMKEEPZEROBIN" THEN 
-    RUN sys/inc/addnk1.p (INPUT cocode, INPUT ip-nk1-value, INPUT NO /* Prompt? */,
-                           INPUT "Keep zero RM bins?",
-                           INPUT "" /* Char Value */, INPUT 0 /* Int value */,
-                           INPUT NO /* Logical value */, INPUT 0 /* dec value*/).
     WHEN "CEGotoCalc" THEN 
     RUN sys/inc/addnk1.p (INPUT cocode, INPUT ip-nk1-value, INPUT NO /* Prompt? */,
         INPUT "Use enhanced GOTO Screen from Estimate?",

--- a/Template/BuildScript/ToCompile/asiUpdateEnv.w
+++ b/Template/BuildScript/ToCompile/asiUpdateEnv.w
@@ -4980,7 +4980,7 @@ PROCEDURE ipUpdateNK1s :
             sys-ctrl.log-fld = TRUE.
     END.
     
-        /* Upgrade Button */
+    /* Upgrade Button */
     RUN ipStatus ("  MenuLinkUpdate").
     FOR EACH  sys-ctrl WHERE
         sys-ctrl.name EQ "MenuLinkUpgrade":
@@ -5032,6 +5032,17 @@ PROCEDURE ipUpdateNK1s :
         ASSIGN
             sys-ctrl.log-fld = TRUE
             sys-ctrl.securityLevelUser = 1000.
+    END.
+    
+    /* 48200 - Deprecate KEEPFROZEN */
+    RUN ipStatus ("  KEEPFROZEN").
+    FOR EACH  sys-ctrl WHERE
+        sys-ctrl.name EQ "FGKEEPZEROBIN":
+        DELETE sys-ctrl.
+    END.
+    FOR EACH  sys-ctrl WHERE
+        sys-ctrl.name EQ "RMKEEPZEROBIN":
+        DELETE sys-ctrl.
     END.
     
     ASSIGN 


### PR DESCRIPTION
Programs changed:
oe/invpost5.i - Ensure variable for KEEPing zero bins is true
oe/invpost6.i - Ensure variable for KEEPing zero bins is true
oe/oe-bolp6.i - Ensure variable for KEEPing zero bins is true
rm/r-rmte&p.w - Ensure variable for KEEPing zero bins is true
sys/inc/create_nk1.p - remove references to KEEPZEROBIN NK1s
asiUpdateENV.w - add sub-procedure to delete NK1s