### PR TITLE
42577-2 Request - Auto Release of Web Orders

### DIFF
--- a/Legacy/system/oeValidate.p
+++ b/Legacy/system/oeValidate.p
@@ -82,7 +82,8 @@ PROCEDURE pCustomerPN PRIVATE:
 
     FOR EACH boe-ordl NO-LOCK WHERE 
         boe-ordl.company EQ ipboe-ord.company AND 
-        boe-ordl.ord-no EQ ipboe-ord.ord-no:
+        boe-ordl.ord-no EQ ipboe-ord.ord-no AND 
+        boe-ordl.line NE 0:
         FIND FIRST bitemfg NO-LOCK WHERE
             bitemfg.company EQ boe-ordl.company AND 
             bitemfg.cust-no EQ boe-ordl.cust-no AND 
@@ -132,7 +133,8 @@ PROCEDURE pPriceGtCost PRIVATE:
 
     FOR EACH boe-ordl NO-LOCK WHERE 
         boe-ordl.company EQ ipboe-ord.company AND 
-        boe-ordl.ord-no EQ ipboe-ord.ord-no:
+        boe-ordl.ord-no EQ ipboe-ord.ord-no AND 
+        boe-ordl.line NE 0:
         IF boe-ordl.t-price LT boe-ordl.t-cost THEN ASSIGN 
             cBadLines = cBadLines + STRING(boe-ordl.line) + ",".
     END.
@@ -243,7 +245,8 @@ PROCEDURE pValidUoM PRIVATE:
 
     FOR EACH boe-ordl NO-LOCK WHERE 
         boe-ordl.company EQ ipboe-ord.company AND 
-        boe-ordl.ord-no EQ ipboe-ord.ord-no:
+        boe-ordl.ord-no EQ ipboe-ord.ord-no AND 
+        boe-ordl.line NE 0:
         IF boe-ordl.pr-uom EQ "" THEN ASSIGN 
                 cBadLines = cBadLines + STRING(boe-ordl.line) + ",".
         ELSE IF NOT CAN-FIND(FIRST uom WHERE uom.uom EQ boe-ordl.pr-uom) THEN ASSIGN 


### PR DESCRIPTION
File changed:
system/oeValidate.w
modified procs that evaluate lines-on-order to exclude line 0.
This gets created when adding order from an estimate, but is not populated until AFTER order is saved.