### PR TITLE
48888 UI/tab Issues when selecting Order from Browser

### DIFF
--- a/Legacy/oe/v-ord.w
+++ b/Legacy/oe/v-ord.w
@@ -5265,9 +5265,10 @@ PROCEDURE local-display-fields :
   RUN dispatch IN THIS-PROCEDURE ( INPUT 'display-fields':U ) .
 
   /* Code placed here will execute AFTER standard behavior.    */
+    /*
     ASSIGN 
         imgHoldRsn:VISIBLE IN FRAME {&frame-name} = TRUE.
-         
+    */     
   
   DO WITH FRAME {&FRAME-NAME}:
       ASSIGN oe-ord.spare-char-2:TOOLTIP =  getOrdStatDescr(oe-ord.spare-char-2:SCREEN-VALUE).      


### PR DESCRIPTION
File changed: oe/v-ord.w
Apparently, assigning a visible widget to visible = TRUE brings it to the front of the window stack.  Who knew?