### PR TITLE
50641 alias not working

### DIFF
--- a/Template/BuildScript/ToCompile/asiLogin.w
+++ b/Template/BuildScript/ToCompile/asiLogin.w
@@ -228,7 +228,7 @@ IF SEARCH(cMapDir + "\" + cAdminDir + "\advantzware.ini") EQ ? THEN DO:
 END.
 
 /* Find the .usr file containing user-level settings */
-RUN ipFindIniFile ("N:\Admin\advantzware.usr",
+RUN ipFindIniFile ("..\advantzware.usr",
                    OUTPUT cUsrLoc).
 ASSIGN 
     FILE-INFO:FILE-NAME = cUsrLoc


### PR DESCRIPTION
File changed: asiLogin.w
In some environments (Premier only), pulling wrong advantzware.usr file