### PR TITLE
52318 High Importance - Ship To Logic in Price Matrix

### DIFF
--- a/Legacy/ed/asi/i850.p
+++ b/Legacy/ed/asi/i850.p
@@ -589,6 +589,7 @@ FOR EACH eddoc
             oe-ordl.company       = oe-ord.company
             oe-ordl.ord-no        = oe-ord.ord-no
             oe-ordl.cust-no       = oe-ord.cust-no
+            oe-ordl.ship-id       = oe-ord.ship-id
             oe-ordl.line          = edpoline.line
             oe-ordl.part-no       = edpoline.cust-item-no
             oe-ordl.i-no          = edpoline.item-no

--- a/Legacy/oe/d-oeitem.w
+++ b/Legacy/oe/d-oeitem.w
@@ -3355,6 +3355,7 @@ IF AVAIL oe-ord THEN DO:
     bf-oe-ordl.ord-no    = oe-ord.ord-no
     bf-oe-ordl.type-code = oe-ord.type
     bf-oe-ordl.cust-no   = oe-ord.cust-no
+    bf-oe-ordl.ship-id   = oe-ord.ship-id
     bf-oe-ordl.po-no     = oe-ord.po-no
     bf-oe-ordl.req-code  = oe-ord.due-code
     bf-oe-ordl.req-date  = oe-ord.due-date

--- a/Legacy/oe/oelibupl.p
+++ b/Legacy/oe/oelibupl.p
@@ -1231,6 +1231,7 @@ PROCEDURE create-item :
     bf-oe-ordl.ord-no    = oe-ord.ord-no
     bf-oe-ordl.type-code = oe-ord.TYPE
     bf-oe-ordl.cust-no   = oe-ord.cust-no
+    bf-oe-ordl.ship-id   = oe-ord.ship-id
     bf-oe-ordl.po-no     = oe-ord.po-no
     bf-oe-ordl.req-code  = oe-ord.due-code
     bf-oe-ordl.req-date  = oe-ord.due-date

--- a/Template/BuildScript/ToCompile/asiUpdateEnv.w
+++ b/Template/BuildScript/ToCompile/asiUpdateEnv.w
@@ -2168,6 +2168,8 @@ PROCEDURE ipDataFix :
         RUN ipDataFix160899.
     IF fIntVer(cThisEntry) LT 16100000 THEN
         RUN ipDataFix161000.
+    IF fIntVer(cThisEntry) LT 16110000 THEN
+        RUN ipDataFix161100.
 
     RUN ipDeleteAudit.
 
@@ -2535,7 +2537,7 @@ END PROCEDURE.
 
 
 
-&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipDataFix160899 C-Win 
+&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipDataFix161000 C-Win 
 PROCEDURE ipDataFix161000 :
     /*------------------------------------------------------------------------------
      Purpose:
@@ -2544,6 +2546,22 @@ PROCEDURE ipDataFix161000 :
     RUN ipStatus ("  Data Fix 161000...").
 
     RUN ipAddJobMchSeq.
+
+END PROCEDURE.
+
+/* _UIB-CODE-BLOCK-END */
+&ANALYZE-RESUME
+
+
+&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipDataFix161100 C-Win 
+PROCEDURE ipDataFix161100 :
+    /*------------------------------------------------------------------------------
+     Purpose:
+     Notes:
+    ------------------------------------------------------------------------------*/
+    RUN ipStatus ("  Data Fix 161100...").
+
+    RUN ipFixBlankOrdlShipIDs.
 
 END PROCEDURE.
 
@@ -3018,6 +3036,33 @@ END PROCEDURE.
 
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
+
+
+
+&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipFixBlankOrdlShipIDs C-Win
+PROCEDURE ipFixBlankOrdlShipIDs:
+/*------------------------------------------------------------------------------
+ Purpose:
+ Notes:
+------------------------------------------------------------------------------*/
+    DISABLE TRIGGERS FOR LOAD OF oe-ordl.
+    RUN ipStatus("   Fix blank oe-ordl ship-ids").
+    FOR EACH oe-ordl EXCLUSIVE-LOCK
+        WHERE oe-ordl.ship-id EQ ""
+        :
+        FIND FIRST oe-ord NO-LOCK WHERE 
+            oe-ord.company EQ oe-ordl.company AND 
+            oe-ord.ord-no EQ oe-ordl.ord-no
+            NO-ERROR.
+        IF AVAIL oe-ord THEN ASSIGN 
+            oe-ordl.ship-id = oe-ord.ship-id.
+    END.
+
+END PROCEDURE.
+	
+/* _UIB-CODE-BLOCK-END */
+&ANALYZE-RESUME
+
 
 
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipFixFrtPay C-Win


### PR DESCRIPTION
Programs changed:
ed/asi/i850.p - add assignment of oe-ordl.ship-id from oe-ord.ship-id on create
oe-oelibupl.p - add assignment of oe-ordl.ship-id from oe-ord.ship-id on create
oe/d-oeitem.w - add assignment of oe-ordl.ship-id from oe-ord.ship-id on create
asiUpdateEnv.w - find and correct any order lines with blank ship-ids.

Note: only oe/d-oeitem.w will be tested for this ticket.  Update program will test following pre-release upgrade.  Others were determined to create order lines with unassigned ship-ids during code GREP and may be obsolete.