### PR TITLE
48270 Error with blank password - failed testing

### DIFF
--- a/Legacy/viewers/users.w
+++ b/Legacy/viewers/users.w
@@ -1021,6 +1021,9 @@ ON LEAVE OF fiPassword IN FRAME F-Main /* Password */
 OR RETURN OF fiPassword
 DO:
     DEF VAR lPwdOK AS LOG NO-UNDO.
+    
+    IF LASTKEY EQ -1 THEN RETURN.
+    
     RUN ipCheckPwd (INPUT-OUTPUT lPwdOK).
     IF NOT lPwdOK THEN DO:
         ASSIGN SELF:SCREEN-VALUE = "".


### PR DESCRIPTION
Program changed: viewers/users.w
Added test for lastkey -1 in password leave trigger