### PR TITLE
51956 NK1 CEReleases - Transaction Lock on estRelease when calculatin…

### DIFF
--- a/Legacy/cec/kpallet.p
+++ b/Legacy/cec/kpallet.p
@@ -51,7 +51,6 @@ DO TRANSACTION:
 END.
 {sys/inc/f16to32.i}
 
-
 if not avail xeb then find xeb where recid(xeb) = v-eb-id no-lock no-error.
 
 RUN est/assmpart.p (BUFFER xeb, OUTPUT ll-assem-part).
@@ -206,7 +205,7 @@ if not avail stack-size then do:
   return.
 end.
 
-v-code = substr(stack-size.vals,v-kdf-length,1).
+v-code = IF v-kdf-length NE 0 THEN substr(stack-size.vals,v-kdf-length,1) ELSE "".
 
 if v-code eq "" then v-code = substr(stack-size.vals,74,1).
 

--- a/Legacy/cec/v-est3.w
+++ b/Legacy/cec/v-est3.w
@@ -1289,6 +1289,8 @@ ON VALUE-CHANGED OF eb.tr-cnt IN FRAME Corr /* Count */
 DO:
   lv-layers = INT(eb.cas-pal:SCREEN-VALUE) / INT(eb.stacks:SCREEN-VALUE).
   {sys/inc/roundup.i lv-layers}
+  IF lv-layers EQ ? THEN ASSIGN 
+    lv-layers = 0.
   ASSIGN
    eb.tr-cas:SCREEN-VALUE  = STRING(lv-layers)
    eb.cas-pal:SCREEN-VALUE = STRING(INT(eb.tr-cas:SCREEN-VALUE) *

--- a/Legacy/est/dNewMiscUpd.w
+++ b/Legacy/est/dNewMiscUpd.w
@@ -216,8 +216,9 @@ DEFINE FRAME Dialog-Frame
           BGCOLOR 15 FONT 1
     estRelease.stackHeight AT ROW 8.86 COL 21.8 COLON-ALIGNED
           LABEL "Stack Height" FORMAT ">>9" 
-          VIEW-AS COMBO-BOX INNER-LINES 4
-          LIST-ITEM-PAIRS "1","1",
+          VIEW-AS COMBO-BOX INNER-LINES 5
+          LIST-ITEM-PAIRS "0","0",
+                     "1","1",
                      "2","2",
                      "3","3",
                      "4","4"


### PR DESCRIPTION
…g with new "Releases" added to estimate

Files changed:
system/FreightProcs.p - added individual record buffers to various procedures to prevent lock scope creep
cec/kpallet.p - prevent substring position 0 error
cec/v-est3.w - prevent substring position 0 error
est/dNewMiscUpd.w - prevent invalid combo-box entry if stack height not set in estimate