### PR TITLE
53495 Corr Est | Inks/Pack Tag | Releases - Add new record returns error

### DIFF
--- a/Legacy/est/dNewMiscUpd.w
+++ b/Legacy/est/dNewMiscUpd.w
@@ -224,7 +224,6 @@ DEFINE FRAME Dialog-Frame
           LABEL "Stack Height" FORMAT ">>9" 
           VIEW-AS COMBO-BOX INNER-LINES 4
           LIST-ITEM-PAIRS 
-                     "0","0",
                      "1","1",
                      "2","2",
                      "3","3",

--- a/Legacy/est/dNewMiscUpd.w
+++ b/Legacy/est/dNewMiscUpd.w
@@ -224,6 +224,7 @@ DEFINE FRAME Dialog-Frame
           LABEL "Stack Height" FORMAT ">>9" 
           VIEW-AS COMBO-BOX INNER-LINES 4
           LIST-ITEM-PAIRS 
+                     "0","0",
                      "1","1",
                      "2","2",
                      "3","3",

--- a/Legacy/system/FreightProcs.p
+++ b/Legacy/system/FreightProcs.p
@@ -542,6 +542,7 @@ PROCEDURE pCreateEstReleaseBuffer PRIVATE:
             opbf-estRelease.formNo           = ipiFormNo
             opbf-estRelease.blankNo          = ipiBlankNo
             opbf-estRelease.quantity         = ipdQuantity
+            opbf-estRelease.stackHeight      = 1
             opbf-estRelease.palletMultiplier = 1
             opbf-estRelease.monthsAtShipFrom = 0
             opbf-estRelease.estReleaseID     = fGetNextEstReleaseID()


### PR DESCRIPTION
I had fixed this in #51956, but was broken again with Sewa's #53275.
File changed: est/dMewMiscUpd.w
Added value "0" to selection list for stack height