### PR TITLE
Feature/53495 corr est inks pack tab  releases   add new record returns error

### DIFF
--- a/Legacy/est/dNewMiscUpd.w
+++ b/Legacy/est/dNewMiscUpd.w
@@ -224,7 +224,6 @@ DEFINE FRAME Dialog-Frame
           LABEL "Stack Height" FORMAT ">>9" 
           VIEW-AS COMBO-BOX INNER-LINES 4
           LIST-ITEM-PAIRS 
-                     "0","0",
                      "1","1",
                      "2","2",
                      "3","3",

--- a/Legacy/est/dNewMiscUpd.w
+++ b/Legacy/est/dNewMiscUpd.w
@@ -224,6 +224,7 @@ DEFINE FRAME Dialog-Frame
           LABEL "Stack Height" FORMAT ">>9" 
           VIEW-AS COMBO-BOX INNER-LINES 4
           LIST-ITEM-PAIRS 
+                     "0","0",
                      "1","1",
                      "2","2",
                      "3","3",

--- a/Legacy/system/FreightProcs.p
+++ b/Legacy/system/FreightProcs.p
@@ -811,7 +811,7 @@ PROCEDURE pUpdateEstReleaseFromEstBlank PRIVATE:
         ipbf-estRelease.shipFromLocationID      = ipbf-eb.loc    
         ipbf-estRelease.quantityPerSubUnit      = ipbf-eb.cas-cnt
         ipbf-estRelease.quantitySubUnitsPerUnit = ipbf-eb.cas-pal
-        ipbf-estRelease.stackHeight             = ipbf-eb.stackHeight
+        ipbf-estRelease.stackHeight             = MAXIMUM(ipbf-eb.stackHeight,1)
         ipbf-estRelease.quantityRelease         = ipbf-estRelease.quantity 
         ipbf-estRelease.dimEachLen              = ipbf-eb.t-len
         ipbf-estRelease.dimEachWid              = ipbf-eb.t-wid

--- a/Legacy/system/FreightProcs.p
+++ b/Legacy/system/FreightProcs.p
@@ -542,6 +542,7 @@ PROCEDURE pCreateEstReleaseBuffer PRIVATE:
             opbf-estRelease.formNo           = ipiFormNo
             opbf-estRelease.blankNo          = ipiBlankNo
             opbf-estRelease.quantity         = ipdQuantity
+            opbf-estRelease.stackHeight      = 1
             opbf-estRelease.palletMultiplier = 1
             opbf-estRelease.monthsAtShipFrom = 0
             opbf-estRelease.estReleaseID     = fGetNextEstReleaseID()


### PR DESCRIPTION
53495 Corr Est | Inks/Pack Tag | Releases - Add new record returns error
File changed: system/FreightProcs.p
When updating an estRelease from EB, ensure stackHeight GT 0.