### PR TITLE
54236 Sharpshooter - remove from menu - BL4 and BL5

### DIFF
--- a/Legacy/loadtags/d-ldfgit.w
+++ b/Legacy/loadtags/d-ldfgit.w
@@ -239,7 +239,7 @@ PROCEDURE enable_UI :
                These statements here are based on the "Other 
                Settings" section of the widget Property Sheets.
 ------------------------------------------------------------------------------*/
-  ENABLE Btn_fg Btn_rm Btn_case Btn_wip 
+  ENABLE Btn_fg Btn_rm Btn_case /* Btn_wip */
       WITH FRAME Dialog-Frame.
   VIEW FRAME Dialog-Frame.
   {&OPEN-BROWSERS-IN-QUERY-Dialog-Frame}


### PR DESCRIPTION
apparently, hiding button isn't enough since local-enable has explicit references
removed button here as well