### PR TITLE
54473 16.13.0 Upgrade error - Live System down

### DIFF
--- a/Template/BuildScript/ToCompile/asiUpdateEnv.w
+++ b/Template/BuildScript/ToCompile/asiUpdateEnv.w
@@ -6072,7 +6072,7 @@ PROCEDURE ipWriteIniFile :
             /* #53853 New 'mode': AutoLogout */
             IF ttIniFile.cVarName EQ "modeList"
             AND LOOKUP("AutoLogout",ttIniFile.cVarValue) EQ 0 THEN ASSIGN 
-                ttIniFile.cVarName= ttIniFile.cVarValue + ",AutoLogout". 
+                ttIniFile.cVarValue = ttIniFile.cVarValue + ",AutoLogout". 
             IF ttIniFile.cVarName EQ "pgmList"
             AND LOOKUP("userControl/monitor.w",ttIniFile.cVarValue) EQ 0 THEN ASSIGN 
                 ttIniFile.cVarValue = ttIniFile.cVarValue + ",userControl/monitor.w". 


### PR DESCRIPTION
File changed: asiUpdateEnv.w - corrected issue that would update the "modelist' advantzware.ini line incorrectly
File changed (not source controlled) preRun161200.r - compiled program using wrong DB version