### PR TITLE
Ticket - 55302 Prep and Die File - error when there is a negative markup: ** Value -XX cannot be displayed using >>9.99.

### DIFF
--- a/Source/methods/lstlogic/custom/prep_.i
+++ b/Source/methods/lstlogic/custom/prep_.i
@@ -26,7 +26,7 @@
 DISPLAY
   prep.code FORMAT "x(15)"
   prep.dscr
-  prep.mkup
+  prep.mkup FORMAT "->>9.99"
   prep.cost
   prep.ml
   prep.amtz


### PR DESCRIPTION
Please review this change and merge into development branch
Files - methods/lstlogic/custom/prep_.i