### PR TITLE
54634 Touch screen Shifts - getting error on add of breaks to the shift

### DIFF
--- a/Source/touch/b-sftbrk.w
+++ b/Source/touch/b-sftbrk.w
@@ -1,7 +1,7 @@
 &ANALYZE-SUSPEND _VERSION-NUMBER UIB_v8r12 GUI ADM1
 &ANALYZE-RESUME
 /* Connected Databases 
-          emptrack         PROGRESS
+          asi         PROGRESS
 */
 &Scoped-define WINDOW-NAME CURRENT-WINDOW
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _CUSTOM _DEFINITIONS B-table-Win 

--- a/Source/touch/v-sftbrk.w
+++ b/Source/touch/v-sftbrk.w
@@ -1,7 +1,7 @@
 &ANALYZE-SUSPEND _VERSION-NUMBER UIB_v8r12 GUI ADM1
 &ANALYZE-RESUME
 /* Connected Databases 
-          emptrack         PROGRESS
+          asi         PROGRESS
 */
 &Scoped-define WINDOW-NAME CURRENT-WINDOW
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _CUSTOM _DEFINITIONS V-table-Win 
@@ -37,6 +37,7 @@ CREATE WIDGET-POOL.
 {custom/globdefs.i}
 
 DEF VAR correct-error AS LOG NO-UNDO.
+DEF VAR lAddingRecord AS LOG NO-UNDO.
 
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
@@ -443,7 +444,7 @@ END.
 
 
 /* ***************************  Main Block  *************************** */
-
+{sys/inc/f3helpd.i} 
   &IF DEFINED(UIB_IS_RUNNING) <> 0 &THEN          
     RUN dispatch IN THIS-PROCEDURE ('initialize':U).        
   &ENDIF         
@@ -614,7 +615,8 @@ PROCEDURE local-create-record :
 
   ASSIGN shift_break.company = shifts.company
          shift_break.shift = shifts.shift
-         shift_break.seq = lv-seq + 1.
+         shift_break.seq = lv-seq + 1
+         lAddingRecord = TRUE.
 
 
 END PROCEDURE.
@@ -630,13 +632,16 @@ PROCEDURE local-delete-record :
 ------------------------------------------------------------------------------*/
 
   /* Code placed here will execute PRIOR to standard behavior. */
-  {custom/askdel.i}
+  IF NOT lAddingRecord THEN DO:
+    {custom/askdel.i}
+  END.
 
   /* Dispatch standard ADM method.                             */
   RUN dispatch IN THIS-PROCEDURE ( INPUT 'delete-record':U ) .
 
   /* Code placed here will execute AFTER standard behavior.    */
-
+    ASSIGN 
+        lAddingRecord = FALSE.
 
 END PROCEDURE.
 
@@ -761,6 +766,8 @@ PROCEDURE local-update-record :
 
   /* Code placed here will execute AFTER standard behavior.    */
    DISABLE {&list-5} WITH FRAME {&FRAME-NAME}.
+    ASSIGN 
+        lAddingRecord = FALSE.
 
 END PROCEDURE.
 

--- a/Source/touch/vi-sifht.w
+++ b/Source/touch/vi-sifht.w
@@ -1,7 +1,7 @@
 &ANALYZE-SUSPEND _VERSION-NUMBER UIB_v8r12 GUI ADM1
 &ANALYZE-RESUME
 /* Connected Databases 
-          emptrack         PROGRESS
+          asi         PROGRESS
 */
 &Scoped-define WINDOW-NAME CURRENT-WINDOW
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _CUSTOM _DEFINITIONS V-table-Win 

--- a/Source/windows/shifts.w
+++ b/Source/windows/shifts.w
@@ -1,7 +1,7 @@
 &ANALYZE-SUSPEND _VERSION-NUMBER UIB_v8r12 GUI ADM1
 &ANALYZE-RESUME
 /* Connected Databases 
-          emptrack         PROGRESS
+          asi         PROGRESS
 */
 &Scoped-define WINDOW-NAME W-Win
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _CUSTOM _DEFINITIONS W-Win 
@@ -183,7 +183,7 @@ ASSIGN FRAME message-frame:FRAME = FRAME F-Main:HANDLE
 DEFINE VARIABLE XXTABVALXX AS LOGICAL NO-UNDO.
 
 ASSIGN XXTABVALXX = FRAME OPTIONS-FRAME:MOVE-BEFORE-TAB-ITEM (FRAME message-frame:HANDLE)
-/* END-ASSIGN-TABS */.
+    /* END-ASSIGN-TABS */.
 
 /* SETTINGS FOR FRAME message-frame
                                                                         */
@@ -257,6 +257,7 @@ END.
 /* ***************************  Main Block  *************************** */
 
 /* Include custom  Main Block code for SmartWindows. */
+{sys/inc/f3helpd.i} 
 {src/adm/template/windowmn.i}
 
 /* _UIB-CODE-BLOCK-END */
@@ -388,7 +389,7 @@ PROCEDURE adm-create-objects :
     END. /* Page 2 */
     WHEN 3 THEN DO:
        RUN init-object IN THIS-PROCEDURE (
-             INPUT  'addon/touch/vi-sifht.w':U ,
+             INPUT  'touch/vi-sifht.w':U ,
              INPUT  FRAME F-Main:HANDLE ,
              INPUT  'Layout = ':U ,
              OUTPUT h_vi-sifht ).
@@ -396,7 +397,7 @@ PROCEDURE adm-create-objects :
        /* Size in UIB:  ( 1.43 , 63.00 ) */
 
        RUN init-object IN THIS-PROCEDURE (
-             INPUT  'addon/touch/b-sftbrk.w':U ,
+             INPUT  'touch/b-sftbrk.w':U ,
              INPUT  FRAME F-Main:HANDLE ,
              INPUT  'Layout = ':U ,
              OUTPUT h_b-sftbrk ).
@@ -404,7 +405,7 @@ PROCEDURE adm-create-objects :
        RUN set-size IN h_b-sftbrk ( 8.10 , 18.60 ) NO-ERROR.
 
        RUN init-object IN THIS-PROCEDURE (
-             INPUT  'addon/touch/v-sftbrk.w':U ,
+             INPUT  'touch/v-sftbrk.w':U ,
              INPUT  FRAME F-Main:HANDLE ,
              INPUT  'Initial-Lock = NO-LOCK,
                      Hide-on-Init = no,


### PR DESCRIPTION
Files changed:
windows/shifts.w - changed references to remove addon dir
touch/b-sftbrk.w - changed DB reference
touch/vi-shht.w - changed DB reference
touch/v-sftbrk.w - changed DB reference
add lAddingRecord flag so that delete doesn't prompt, just deletes
added F3 help