### PR TITLE
55800 Error entering order: ** OE Release Master already exists with …

### DIFF
--- a/Source/oe/getNextRelNo.p
+++ b/Source/oe/getNextRelNo.p
@@ -12,15 +12,42 @@
     DEF VAR iLastRelNo AS INT NO-UNDO.
 
     CASE ipMode:
-        WHEN "oe-rel" THEN ASSIGN 
-            opNextRelNo = NEXT-VALUE(oerel_rno_seq).
+        WHEN "oe-rel" THEN DO:
+            ASSIGN 
+                opNextRelNo = NEXT-VALUE(oerel_rno_seq).
+            /* This SHOULD take care of situations where an out-of-sequence r-no has been added, */
+            /* such that the sequence generator is updated to the latest (correct) r-no.         */
+            /* Since this is not a consistent error, there is some sequence of events/processes  */
+            /* that create this condition, but all reported cases have been resolved within 1-2  */
+            /* sequence numbers                                                                  */
+            DO WHILE CAN-FIND(FIRST oe-rel WHERE
+                oe-rel.company EQ cocode AND
+                oe-rel.r-no EQ opNextRelNo):
+                ASSIGN 
+                    opNextRelNo = NEXT-VALUE(oerel_rno_seq).
+            END.
+        END.
         WHEN "release#" THEN DO:
+            /* The caller program here (oe/release#.p) contains additional logic, so don't want to change what works */
             RUN sys/ref/asiseq.p (cocode,
                                   "oerel_release_seq",
                                   OUTPUT opNextRelNo).
         END.
-        WHEN "oe-relh" THEN ASSIGN
-            opNextRelNo = NEXT-VALUE(oerel_release_seq).
+        WHEN "oe-relh" THEN DO:
+            ASSIGN
+                opNextRelNo = NEXT-VALUE(oerel_release_seq).
+            /* This SHOULD take care of situations where an out-of-sequence r-no has been added, */
+            /* such that the sequence generator is updated to the latest (correct) r-no.         */
+            /* Since this is not a consistent error, there is some sequence of events/processes  */
+            /* that create this condition, but all reported cases have been resolved within 1-2  */
+            /* sequence numbers                                                                  */
+            DO WHILE CAN-FIND(FIRST oe-relh WHERE
+                oe-relh.company EQ cocode AND
+                oe-relh.r-no EQ opNextRelNo):
+                ASSIGN 
+                    opNextRelNo = NEXT-VALUE(oerel_release_seq).
+            END.
+        END.
         OTHERWISE DO:
             MESSAGE
                 "Entered mode (" + ipMode + ") not supported" SKIP

--- a/Source/oe/oe-rel.a
+++ b/Source/oe/oe-rel.a
@@ -57,7 +57,18 @@ if avail {&fil} then do:
     /* find first oe-rel use-index seq-no no-lock no-error. */
     /* v-nxt-r-no = (if avail oe-rel then oe-rel.r-no else 0) + 1. */
     RUN oe/getNextRelNo.p (INPUT "oe-rel", OUTPUT v-nxt-r-no).
-
+    
+    /* This SHOULD take care of situations where an out-of-sequence r-no has been added, */
+    /* such that the sequence generator is updated to the latest (correct) r-no.         */
+    /* Since this is not a consistent error, there is some sequence of events/processes  */
+    /* that create this condition, but all reported cases have been resolved within 1-2  */
+    /* sequence numbers                                                                  */
+    DO WHILE CAN-FIND(FIRST oe-rel WHERE
+                        oe-rel.company EQ cocode AND
+                        oe-rel.r-no EQ v-nxt-r-no):
+        RUN oe/getNextRelNo.p (INPUT "oe-rel", OUTPUT v-nxt-r-no).
+    END.
+                       
     create oe-rel.
     assign oe-rel.company   = cocode
            oe-rel.loc       = locode

--- a/Source/oe/oe-rel.a
+++ b/Source/oe/oe-rel.a
@@ -58,17 +58,6 @@ if avail {&fil} then do:
     /* v-nxt-r-no = (if avail oe-rel then oe-rel.r-no else 0) + 1. */
     RUN oe/getNextRelNo.p (INPUT "oe-rel", OUTPUT v-nxt-r-no).
     
-    /* This SHOULD take care of situations where an out-of-sequence r-no has been added, */
-    /* such that the sequence generator is updated to the latest (correct) r-no.         */
-    /* Since this is not a consistent error, there is some sequence of events/processes  */
-    /* that create this condition, but all reported cases have been resolved within 1-2  */
-    /* sequence numbers                                                                  */
-    DO WHILE CAN-FIND(FIRST oe-rel WHERE
-                        oe-rel.company EQ cocode AND
-                        oe-rel.r-no EQ v-nxt-r-no):
-        RUN oe/getNextRelNo.p (INPUT "oe-rel", OUTPUT v-nxt-r-no).
-    END.
-                       
     create oe-rel.
     assign oe-rel.company   = cocode
            oe-rel.loc       = locode


### PR DESCRIPTION
…r-no 37521. (132)

File changed: oe/oe-rel.a
Added loop if seqence returns a previously used r-no
This (1) acquires a valid r-no for the release and (2) updates the sequence so next number will be properly incremented