### PR TITLE
55080 Order Processing - additional 'Hold' validations

### DIFF
--- a/Source/browsers/brwTag.w
+++ b/Source/browsers/brwTag.w
@@ -104,7 +104,7 @@ DEFINE BROWSE br_table
   QUERY br_table NO-LOCK DISPLAY
       tagType FORMAT "x(8)":U
       groupCode FORMAT "x(8)":U
-      description FORMAT "x(60)":U WIDTH 35
+      description FORMAT "x(60)":U WIDTH 50
       Note1 FORMAT "x(60)":U
       statusCode FORMAT "x(8)":U
       linkTable FORMAT "x(24)":U
@@ -203,7 +203,7 @@ ASSIGN
 "tagType" ? ? "character" ? ? ? ? ? ? no "?" no no ? yes no no "U" "" "" "" "" "" "" 0 no 0 no no
      _FldNameList[2]   = _<SDO>.rowObject.groupCode
      _FldNameList[3]   > _<SDO>.rowObject.description
-"description" ? ? "character" ? ? ? ? ? ? no "?" no no "35" yes no no "U" "" "" "" "" "" "" 0 no 0 no no
+"description" ? ? "character" ? ? ? ? ? ? no "?" no no "50" yes no no "U" "" "" "" "" "" "" 0 no 0 no no
      _FldNameList[4]   > _<SDO>.rowObject.Note1
 "Note1" ? ? "character" ? ? ? ? ? ? no "?" no no ? yes no no "U" "" "" "" "" "" "" 0 no 0 no no
      _FldNameList[5]   = _<SDO>.rowObject.statusCode

--- a/Source/oe/v-ord.w
+++ b/Source/oe/v-ord.w
@@ -407,7 +407,7 @@ DEFINE BUTTON btnCalendar-6
 
 DEFINE BUTTON btnValidate 
      LABEL "Validate" 
-     SIZE 19 BY 1.05 TOOLTIP "PopUp Calendar".
+     SIZE 21 BY 1.05 TOOLTIP "PopUp Calendar".
 
 DEFINE VARIABLE fiCustAddress AS CHARACTER FORMAT "X(256)":U 
      VIEW-AS FILL-IN 
@@ -426,6 +426,7 @@ DEFINE VARIABLE fiSoldAddress AS CHARACTER FORMAT "X(256)":U
      SIZE 64.2 BY 1 NO-UNDO.
 
 DEFINE VARIABLE fiStatDesc AS CHARACTER FORMAT "X(256)":U 
+     LABEL "Status" 
      VIEW-AS FILL-IN 
      SIZE 31 BY 1 NO-UNDO.
 
@@ -501,7 +502,7 @@ DEFINE RECTANGLE RECT-37
 /* ************************  Frame Definitions  *********************** */
 
 DEFINE FRAME F-Main
-     fiStatDesc AT ROW 9.33 COL 91 COLON-ALIGNED NO-LABEL NO-TAB-STOP 
+     fiStatDesc AT ROW 9.33 COL 87 COLON-ALIGNED NO-TAB-STOP 
      fiText1 AT ROW 12.91 COL 79 COLON-ALIGNED NO-LABEL NO-TAB-STOP 
      fiText2 AT ROW 13.95 COL 109 COLON-ALIGNED NO-LABEL NO-TAB-STOP 
      fiCustAddress AT ROW 3.71 COL 10.8 COLON-ALIGNED NO-LABEL WIDGET-ID 18
@@ -529,10 +530,9 @@ DEFINE FRAME F-Main
           LABEL "Last User"
           VIEW-AS FILL-IN 
           SIZE 17.4 BY 1
-     oe-ord.stat AT ROW 9.33 COL 86 COLON-ALIGNED
-          LABEL "Status"
+     oe-ord.stat AT ROW 14.1 COL 146 COLON-ALIGNED NO-LABEL
           VIEW-AS FILL-IN 
-          SIZE 4.2 BY 1
+          SIZE 4.2 BY 1 NO-TAB-STOP 
      oe-ord.cust-no AT ROW 2.67 COL 10.8 COLON-ALIGNED
           LABEL "Bill To" FORMAT "x(8)"
           VIEW-AS FILL-IN 
@@ -722,7 +722,7 @@ DEFINE FRAME F-Main
           SIZE 17 BY 1
      fiSoldAddress AT ROW 5.81 COL 10.8 COLON-ALIGNED NO-LABEL WIDGET-ID 24
      fiShipAddress AT ROW 7.91 COL 10.8 COLON-ALIGNED NO-LABEL WIDGET-ID 26
-     btnValidate AT ROW 9.33 COL 132
+     btnValidate AT ROW 9.33 COL 130
      oe-ord.spare-char-2 AT ROW 11 COL 78 COLON-ALIGNED NO-LABEL
           VIEW-AS FILL-IN 
           SIZE 3.6 BY 1 NO-TAB-STOP 
@@ -732,7 +732,7 @@ DEFINE FRAME F-Main
      RECT-36 AT ROW 13.71 COL 1.6
      RECT-37 AT ROW 2.52 COL 1.6
      RECT-34 AT ROW 9.1 COL 78 WIDGET-ID 14
-     imgHoldRsn AT ROW 9.52 COL 126
+     imgHoldRsn AT ROW 9.33 COL 122
     WITH 1 DOWN NO-BOX KEEP-TAB-ORDER OVERLAY 
          SIDE-LABELS NO-UNDERLINE THREE-D 
          AT COL 1 ROW 1 SCROLLABLE 
@@ -916,6 +916,9 @@ ASSIGN
 
 /* SETTINGS FOR FILL-IN oe-ord.stat IN FRAME F-Main
    NO-ENABLE 2 EXP-LABEL                                                */
+ASSIGN 
+       oe-ord.stat:HIDDEN IN FRAME F-Main           = TRUE.
+
 /* SETTINGS FOR FILL-IN oe-ord.tax-gr IN FRAME F-Main
    EXP-LABEL                                                            */
 /* SETTINGS FOR FILL-IN oe-ord.terms IN FRAME F-Main
@@ -6280,6 +6283,9 @@ PROCEDURE pValidate :
     
     RUN validateOrder IN spOeValidate (ROWID(oe-ord),OUTPUT lHoldError,OUTPUT cErrMessage).
     
+    ASSIGN 
+        cErrMessage = REPLACE(cErrMessage,"|",CHR(10)).
+        
     IF lHoldError                                                       /* ValidateALL has reported an error */
     AND (DYNAMIC-FUNCTION("isOnHold",oe-ord.rec_key) NE TRUE) THEN DO:  /* BUT there is a manual release tag */
         MESSAGE

--- a/Source/sys/ref/dlgTagVwr.w
+++ b/Source/sys/ref/dlgTagVwr.w
@@ -216,7 +216,7 @@ PROCEDURE adm-create-objects :
        RUN resizeObject IN h_brwtag ( 9.05 , 110.00 ) NO-ERROR.
 
        RUN constructObject (
-             INPUT  'n:/repository/source/viewers/vwrtag.w':U ,
+             INPUT  'viewers/vwrtag.w':U ,
              INPUT  FRAME gDialog:HANDLE ,
              INPUT  'EnabledObjFldsToDisable?ModifyFields(All)DataSourceNamesUpdateTargetNamesLogicalObjectNameLogicalObjectNamePhysicalObjectNameDynamicObjectnoRunAttributeHideOnInitnoDisableOnInitnoObjectLayout':U ,
              OUTPUT h_vwrtag-3 ).

--- a/Source/sys/ref/dlgTagVwr.w
+++ b/Source/sys/ref/dlgTagVwr.w
@@ -79,7 +79,7 @@ DEF VAR cNewQueryString AS CHAR NO-UNDO.
 /* Definitions of handles for SmartObjects                              */
 DEFINE VARIABLE h_brwtag AS HANDLE NO-UNDO.
 DEFINE VARIABLE h_sdotag AS HANDLE NO-UNDO.
-DEFINE VARIABLE h_vwrtag AS HANDLE NO-UNDO.
+DEFINE VARIABLE h_vwrtag-3 AS HANDLE NO-UNDO.
 
 /* Definitions of the field level widgets                               */
 DEFINE BUTTON Btn_OK AUTO-GO 
@@ -96,7 +96,7 @@ DEFINE VARIABLE fiMessage AS CHARACTER FORMAT "X(256)":U
 DEFINE FRAME gDialog
      Btn_OK AT ROW 1.24 COL 98
      fiMessage AT ROW 1.48 COL 1 COLON-ALIGNED NO-LABEL NO-TAB-STOP 
-     SPACE(31.59) SKIP(15.27)
+     SPACE(31.59) SKIP(14.70)
     WITH VIEW-AS DIALOG-BOX KEEP-TAB-ORDER 
          SIDE-LABELS NO-UNDERLINE THREE-D  SCROLLABLE 
          TITLE "Tag Viewer"
@@ -213,25 +213,25 @@ PROCEDURE adm-create-objects :
              INPUT  'ScrollRemotenoNumDown0CalcWidthnoMaxWidth80FetchOnReposToEndyesUseSortIndicatoryesSearchFieldDataSourceNames?UpdateTargetNames?LogicalObjectNameHideOnInitnoDisableOnInitnoObjectLayout':U ,
              OUTPUT h_brwtag ).
        RUN repositionObject IN h_brwtag ( 2.91 , 3.00 ) NO-ERROR.
-       RUN resizeObject IN h_brwtag ( 7.62 , 110.00 ) NO-ERROR.
+       RUN resizeObject IN h_brwtag ( 9.05 , 110.00 ) NO-ERROR.
 
        RUN constructObject (
-             INPUT  'viewers/vwrtag.w':U ,
+             INPUT  'n:/repository/source/viewers/vwrtag.w':U ,
              INPUT  FRAME gDialog:HANDLE ,
              INPUT  'EnabledObjFldsToDisable?ModifyFields(All)DataSourceNamesUpdateTargetNamesLogicalObjectNameLogicalObjectNamePhysicalObjectNameDynamicObjectnoRunAttributeHideOnInitnoDisableOnInitnoObjectLayout':U ,
-             OUTPUT h_vwrtag ).
-       RUN repositionObject IN h_vwrtag ( 10.76 , 3.00 ) NO-ERROR.
-       /* Size in AB:  ( 6.71 , 106.20 ) */
+             OUTPUT h_vwrtag-3 ).
+       RUN repositionObject IN h_vwrtag-3 ( 12.19 , 3.00 ) NO-ERROR.
+       /* Size in AB:  ( 4.81 , 91.00 ) */
 
        /* Links to SmartDataBrowser h_brwtag. */
        RUN addLink ( h_sdotag , 'Data':U , h_brwtag ).
        RUN addLink ( h_brwtag , 'Update':U , h_sdotag ).
 
-       /* Links to SmartDataViewer h_vwrtag. */
-       RUN addLink ( h_sdotag , 'Data':U , h_vwrtag ).
+       /* Links to SmartDataViewer h_vwrtag-3. */
+       RUN addLink ( h_sdotag , 'Data':U , h_vwrtag-3 ).
 
        /* Adjust the tab order of the smart objects. */
-       RUN adjustTabOrder ( h_vwrtag ,
+       RUN adjustTabOrder ( h_vwrtag-3 ,
              h_brwtag , 'AFTER':U ).
     END. /* Page 0 */
 

--- a/Source/system/oeValidate.p
+++ b/Source/system/oeValidate.p
@@ -491,7 +491,7 @@ PROCEDURE ValidateOrder:
                 ASSIGN
                     iCountHold = iCountHold + 1
                     oplHold = TRUE
-                    opcMessage = ttValidation.cHoldMessage.
+                    opcMessage = opcMessage + "|" + ttValidation.cHoldMessage.
             END.    
             ELSE 
             DO:
@@ -500,9 +500,8 @@ PROCEDURE ValidateOrder:
             END.          
         END.
     END.
-    IF iCountHold GT 1 THEN 
-        opcMessage = "Multiple Reasons".
-     
+    ASSIGN 
+        opcMessage = TRIM(opcMessage,"|").
     
 END PROCEDURE.
 

--- a/Source/viewers/vwrTag.w
+++ b/Source/viewers/vwrTag.w
@@ -46,6 +46,8 @@ CREATE WIDGET-POOL.
 
 {src/adm2/widgetprto.i}
 
+DEF VAR cTableName AS CHAR NO-UNDO.
+
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
 
@@ -69,19 +71,20 @@ CREATE WIDGET-POOL.
 
 /* Standard List Definitions                                            */
 &Scoped-Define ENABLED-FIELDS RowObject.rec_key RowObject.linkRecKey ~
-RowObject.linkTable RowObject.createDT RowObject.updateDT ~
-RowObject.createUser RowObject.updateUser 
+RowObject.createDT RowObject.createUser RowObject.updateDT ~
+RowObject.updateUser 
 &Scoped-define ENABLED-TABLES RowObject
 &Scoped-define FIRST-ENABLED-TABLE RowObject
-&Scoped-Define DISPLAYED-FIELDS RowObject.rec_key RowObject.linkRecKey ~
-RowObject.linkTable RowObject.createDT RowObject.updateDT ~
-RowObject.createUser RowObject.updateUser RowObject.tagType ~
-RowObject.groupCode RowObject.statusCode RowObject.ownerUser ~
-RowObject.description RowObject.Note1 RowObject.Note2 RowObject.Note3 ~
-RowObject.Note4 RowObject.Note5 
+&Scoped-Define ENABLED-OBJECTS fiTableName 
+&Scoped-Define DISPLAYED-FIELDS RowObject.rec_key RowObject.linkTable ~
+RowObject.linkRecKey RowObject.tagType RowObject.groupCode ~
+RowObject.statusCode RowObject.ownerUser RowObject.description ~
+RowObject.Note1 RowObject.Note2 RowObject.Note3 RowObject.Note4 ~
+RowObject.Note5 RowObject.createDT RowObject.createUser RowObject.updateDT ~
+RowObject.updateUser 
 &Scoped-define DISPLAYED-TABLES RowObject
 &Scoped-define FIRST-DISPLAYED-TABLE RowObject
-
+&Scoped-Define DISPLAYED-OBJECTS fiTableName 
 
 /* Custom List Definitions                                              */
 /* ADM-ASSIGN-FIELDS,List-2,List-3,List-4,List-5,List-6                 */
@@ -95,63 +98,67 @@ RowObject.Note4 RowObject.Note5
 
 
 /* Definitions of the field level widgets                               */
+DEFINE VARIABLE fiTableName AS CHARACTER FORMAT "X(256)":U 
+     LABEL "Linked to" 
+     VIEW-AS FILL-IN NATIVE 
+     SIZE 43 BY 1 NO-UNDO.
+
 
 /* ************************  Frame Definitions  *********************** */
 
 DEFINE FRAME F-Main
-     RowObject.rec_key AT ROW 1.24 COL 14 COLON-ALIGNED
+     RowObject.rec_key AT ROW 1.24 COL 23 COLON-ALIGNED
+          LABEL "RecKey (this tag)"
           VIEW-AS FILL-IN 
           SIZE 43 BY 1
-     RowObject.linkRecKey AT ROW 2.43 COL 14 COLON-ALIGNED
+     fiTableName AT ROW 2.43 COL 23 COLON-ALIGNED
+     RowObject.linkTable AT ROW 2.43 COL 68 COLON-ALIGNED NO-LABEL
+          VIEW-AS FILL-IN 
+          SIZE 22 BY 1 NO-TAB-STOP 
+     RowObject.linkRecKey AT ROW 3.62 COL 23 COLON-ALIGNED
+          LABEL "Using RecKey"
           VIEW-AS FILL-IN 
           SIZE 43 BY 1
-     RowObject.linkTable AT ROW 2.43 COL 71 COLON-ALIGNED
-          VIEW-AS FILL-IN 
-          SIZE 26 BY 1
-     RowObject.createDT AT ROW 4.1 COL 14 COLON-ALIGNED
-          LABEL "Created"
-          VIEW-AS FILL-IN 
-          SIZE 34.2 BY 1
-     RowObject.updateDT AT ROW 4.1 COL 71 COLON-ALIGNED
-          LABEL "Updated"
-          VIEW-AS FILL-IN 
-          SIZE 34.2 BY 1
-     RowObject.createUser AT ROW 5.29 COL 14 COLON-ALIGNED
-          LABEL "By"
-          VIEW-AS FILL-IN 
-          SIZE 18.2 BY 1
-     RowObject.updateUser AT ROW 5.29 COL 71 COLON-ALIGNED
-          LABEL "By"
-          VIEW-AS FILL-IN 
-          SIZE 18.2 BY 1
-     RowObject.tagType AT ROW 6.71 COL 4 COLON-ALIGNED NO-LABEL
+     RowObject.tagType AT ROW 4.81 COL 5 COLON-ALIGNED NO-LABEL
           VIEW-AS FILL-IN 
           SIZE 5.2 BY 1 NO-TAB-STOP 
-     RowObject.groupCode AT ROW 6.71 COL 10 COLON-ALIGNED NO-LABEL
+     RowObject.groupCode AT ROW 4.81 COL 11 COLON-ALIGNED NO-LABEL
           VIEW-AS FILL-IN 
           SIZE 4.2 BY 1 NO-TAB-STOP 
-     RowObject.statusCode AT ROW 6.71 COL 15 COLON-ALIGNED NO-LABEL
+     RowObject.statusCode AT ROW 4.81 COL 16 COLON-ALIGNED NO-LABEL
           VIEW-AS FILL-IN 
           SIZE 4.2 BY 1 NO-TAB-STOP 
-     RowObject.ownerUser AT ROW 6.71 COL 20 COLON-ALIGNED NO-LABEL
+     RowObject.ownerUser AT ROW 4.81 COL 21 COLON-ALIGNED NO-LABEL
           VIEW-AS FILL-IN 
           SIZE 4.2 BY 1 NO-TAB-STOP 
-     RowObject.description AT ROW 6.71 COL 25 COLON-ALIGNED NO-LABEL
+     RowObject.description AT ROW 4.81 COL 26 COLON-ALIGNED NO-LABEL
           VIEW-AS FILL-IN 
           SIZE 4 BY 1 NO-TAB-STOP 
-     RowObject.Note1 AT ROW 6.71 COL 30 COLON-ALIGNED NO-LABEL
+     RowObject.Note1 AT ROW 4.81 COL 31 COLON-ALIGNED NO-LABEL
           VIEW-AS FILL-IN 
           SIZE 5 BY 1 NO-TAB-STOP 
-     RowObject.Note2 AT ROW 6.71 COL 35 COLON-ALIGNED NO-LABEL
+     RowObject.Note2 AT ROW 4.81 COL 36 COLON-ALIGNED NO-LABEL
           VIEW-AS FILL-IN 
           SIZE 4 BY 1 NO-TAB-STOP 
-     RowObject.Note3 AT ROW 6.71 COL 40 COLON-ALIGNED NO-LABEL
+     RowObject.Note3 AT ROW 4.81 COL 41 COLON-ALIGNED NO-LABEL
           VIEW-AS FILL-IN 
           SIZE 4 BY 1 NO-TAB-STOP 
-     RowObject.Note4 AT ROW 6.71 COL 45 COLON-ALIGNED NO-LABEL
+     RowObject.Note4 AT ROW 4.81 COL 46 COLON-ALIGNED NO-LABEL
           VIEW-AS FILL-IN 
           SIZE 5 BY 1 NO-TAB-STOP 
-     RowObject.Note5 AT ROW 6.71 COL 51 COLON-ALIGNED NO-LABEL
+     RowObject.Note5 AT ROW 4.81 COL 52 COLON-ALIGNED NO-LABEL
+          VIEW-AS FILL-IN 
+          SIZE 4 BY 1 NO-TAB-STOP 
+     RowObject.createDT AT ROW 4.81 COL 58 COLON-ALIGNED NO-LABEL
+          VIEW-AS FILL-IN 
+          SIZE 4 BY 1 NO-TAB-STOP 
+     RowObject.createUser AT ROW 4.81 COL 63 COLON-ALIGNED NO-LABEL
+          VIEW-AS FILL-IN 
+          SIZE 4 BY 1 NO-TAB-STOP 
+     RowObject.updateDT AT ROW 4.81 COL 68 COLON-ALIGNED NO-LABEL
+          VIEW-AS FILL-IN 
+          SIZE 4 BY 1 NO-TAB-STOP 
+     RowObject.updateUser AT ROW 4.81 COL 73 COLON-ALIGNED NO-LABEL
           VIEW-AS FILL-IN 
           SIZE 4 BY 1 NO-TAB-STOP 
     WITH 1 DOWN NO-BOX KEEP-TAB-ORDER OVERLAY USE-DICT-EXPS 
@@ -193,7 +200,7 @@ END.
 &ANALYZE-SUSPEND _CREATE-WINDOW
 /* DESIGN Window definition (used by the UIB) 
   CREATE WINDOW vTable ASSIGN
-         HEIGHT             = 6.91
+         HEIGHT             = 5.19
          WIDTH              = 112.6.
 /* END WINDOW DEFINITION */
                                                                         */
@@ -223,17 +230,36 @@ ASSIGN
 
 /* SETTINGS FOR FILL-IN RowObject.createDT IN FRAME F-Main
    EXP-LABEL                                                            */
+ASSIGN 
+       RowObject.createDT:HIDDEN IN FRAME F-Main           = TRUE.
+
 /* SETTINGS FOR FILL-IN RowObject.createUser IN FRAME F-Main
    EXP-LABEL                                                            */
+ASSIGN 
+       RowObject.createUser:HIDDEN IN FRAME F-Main           = TRUE.
+
 /* SETTINGS FOR FILL-IN RowObject.description IN FRAME F-Main
    NO-ENABLE                                                            */
 ASSIGN 
        RowObject.description:HIDDEN IN FRAME F-Main           = TRUE.
 
+ASSIGN 
+       fiTableName:READ-ONLY IN FRAME F-Main        = TRUE.
+
 /* SETTINGS FOR FILL-IN RowObject.groupCode IN FRAME F-Main
    NO-ENABLE                                                            */
 ASSIGN 
        RowObject.groupCode:HIDDEN IN FRAME F-Main           = TRUE.
+
+/* SETTINGS FOR FILL-IN RowObject.linkRecKey IN FRAME F-Main
+   EXP-LABEL                                                            */
+ASSIGN 
+       RowObject.linkRecKey:READ-ONLY IN FRAME F-Main        = TRUE.
+
+/* SETTINGS FOR FILL-IN RowObject.linkTable IN FRAME F-Main
+   NO-ENABLE                                                            */
+ASSIGN 
+       RowObject.linkTable:READ-ONLY IN FRAME F-Main        = TRUE.
 
 /* SETTINGS FOR FILL-IN RowObject.Note1 IN FRAME F-Main
    NO-ENABLE EXP-LABEL                                                  */
@@ -265,6 +291,11 @@ ASSIGN
 ASSIGN 
        RowObject.ownerUser:HIDDEN IN FRAME F-Main           = TRUE.
 
+/* SETTINGS FOR FILL-IN RowObject.rec_key IN FRAME F-Main
+   EXP-LABEL                                                            */
+ASSIGN 
+       RowObject.rec_key:READ-ONLY IN FRAME F-Main        = TRUE.
+
 /* SETTINGS FOR FILL-IN RowObject.statusCode IN FRAME F-Main
    NO-ENABLE                                                            */
 ASSIGN 
@@ -277,8 +308,14 @@ ASSIGN
 
 /* SETTINGS FOR FILL-IN RowObject.updateDT IN FRAME F-Main
    EXP-LABEL                                                            */
+ASSIGN 
+       RowObject.updateDT:HIDDEN IN FRAME F-Main           = TRUE.
+
 /* SETTINGS FOR FILL-IN RowObject.updateUser IN FRAME F-Main
    EXP-LABEL                                                            */
+ASSIGN 
+       RowObject.updateUser:HIDDEN IN FRAME F-Main           = TRUE.
+
 /* _RUN-TIME-ATTRIBUTES-END */
 &ANALYZE-RESUME
 
@@ -325,6 +362,30 @@ PROCEDURE disable_UI :
   /* Hide all frames. */
   HIDE FRAME F-Main.
   IF THIS-PROCEDURE:PERSISTENT THEN DELETE PROCEDURE THIS-PROCEDURE.
+END PROCEDURE.
+
+/* _UIB-CODE-BLOCK-END */
+&ANALYZE-RESUME
+
+&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE displayRecord vTable 
+PROCEDURE displayRecord :
+/*------------------------------------------------------------------------------
+ Purpose:
+ Notes:
+------------------------------------------------------------------------------*/
+
+  /* Code placed here will execute PRIOR to standard behavior. */
+
+  RUN SUPER.
+
+  /* Code placed here will execute AFTER standard behavior.    */
+    FIND FIRST _file NO-LOCK WHERE 
+        _file._file-name EQ rowobject.linkTable:SCREEN-VALUE IN FRAME {&frame-name}
+        NO-ERROR. 
+    ASSIGN 
+        fiTableName = IF AVAIL _file THEN _file._file-label ELSE "".
+        
+
 END PROCEDURE.
 
 /* _UIB-CODE-BLOCK-END */


### PR DESCRIPTION
Files changed:
browsers/brwTag.w - expanded description field
oe/v-ord.w - removed status field
- allowed hold alert to display multiple failure types
sys/ref/dlgTagVwr.w - modified viewer and spacing
system/oevalidate.p - provided support for multiple fail message passing
viewerw/vwrTag.w - removed most fields, made labels more descriptive