### PR TITLE
50997 Inventory by Item Name report - incorrect extended Value when '…

### DIFF
--- a/Source/rm/rm-mkbin.i
+++ b/Source/rm/rm-mkbin.i
@@ -20,7 +20,7 @@ END.
 
 if ld-cst ne ?                              and
    (rm-rcpth.rita-code eq "R" or
-    (can-do("A,T",rm-rcpth.rita-code) and
+    (can-do("A,T,C",rm-rcpth.rita-code) and
      ld-cst ne 0))                          then do:
 
   IF rm-rcpth.rita-code EQ "A" THEN {1}rm-bin.cost = ld-cst.


### PR DESCRIPTION
…As of' is not the current date