### PR TITLE
53088 Performance Issues during Order Entry Process

### DIFF
--- a/Source/browsers/mailcont.w
+++ b/Source/browsers/mailcont.w
@@ -1,7 +1,7 @@
 &ANALYZE-SUSPEND _VERSION-NUMBER UIB_v8r12 GUI ADM1
 &ANALYZE-RESUME
 /* Connected Databases 
-          emptrack         PROGRESS
+          asi         PROGRESS
 */
 &Scoped-define WINDOW-NAME CURRENT-WINDOW
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _CUSTOM _DEFINITIONS B-table-Win 
@@ -316,7 +316,7 @@ DO:
     lv-cont-recid = ?.
     run windows/l-contac.w (output char-val).
     if char-val <> "" then do:
-       find contact where string(recid(contact)) = char-val no-lock no-error.
+       FIND contact NO-LOCK WHERE RECID(contact) = INT(char-val) NO-ERROR.
        if avail contact then 
            assign lv-cont-recid = recid(contact)
                   mailcont.cust-no:screen-value in browse {&browse-name} = contact.cust-no

--- a/Source/browsers/vendcostmtx.w
+++ b/Source/browsers/vendcostmtx.w
@@ -621,7 +621,7 @@ DO:
 
     RUN windows/l-est.w (g_company,g_loc,"", OUTPUT char-val).
     IF char-val <> "" THEN DO:
-        FIND FIRST eb WHERE STRING(RECID(eb)) = char-val NO-LOCK NO-ERROR.
+        FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
         IF AVAIL eb THEN 
             fi_est-no:screen-value = eb.est-no.
     END.

--- a/Source/cerep/r-estA.w
+++ b/Source/cerep/r-estA.w
@@ -519,7 +519,7 @@ DO:
      run windows/l-est.w (g_company,g_loc,focus:screen-value, output char-val).
 
      if char-val <> "" then do:                 
-            FIND FIRST eb WHERE string(RECID(eb)) = (char-val) NO-LOCK NO-ERROR.
+            FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
             IF AVAIL eb THEN ASSIGN FOCUS:SCREEN-VALUE = eb.est-no
                                            lv-eb-tmpid = RECID(eb)    
                                 begin_est:SCREEN-VALUE = eb.est-no.
@@ -669,7 +669,7 @@ DO:
      run windows/l-est.w (g_company,g_loc,focus:screen-value, output char-val).
 
      if char-val <> "" then do:                 
-            FIND FIRST eb WHERE string(RECID(eb)) = (char-val) NO-LOCK NO-ERROR.
+            FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
             IF AVAIL eb THEN ASSIGN FOCUS:SCREEN-VALUE = eb.est-no
                                            lv-eb-tmpid = RECID(eb)    
                                   end_est:SCREEN-VALUE = eb.est-no.

--- a/Source/cerep/r-estN.w
+++ b/Source/cerep/r-estN.w
@@ -600,7 +600,7 @@ DO:
      run windows/l-est.w (g_company,g_loc,focus:screen-value, output char-val).
 
      if char-val <> "" then do:                 
-            FIND FIRST eb WHERE string(RECID(eb)) = (char-val) NO-LOCK NO-ERROR.
+         FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
             IF AVAIL eb THEN ASSIGN FOCUS:SCREEN-VALUE = eb.est-no
                                            lv-eb-tmpid = RECID(eb)    
                                 begin_est:SCREEN-VALUE = eb.est-no.
@@ -830,7 +830,7 @@ DO:
      run windows/l-est.w (g_company,g_loc,focus:screen-value, output char-val).
 
      if char-val <> "" then do:                 
-            FIND FIRST eb WHERE string(RECID(eb)) = (char-val) NO-LOCK NO-ERROR.
+         FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
             IF AVAIL eb THEN ASSIGN FOCUS:SCREEN-VALUE = eb.est-no
                                            lv-eb-tmpid = RECID(eb)    
                                   end_est:SCREEN-VALUE = eb.est-no.

--- a/Source/cerep/r-estmarA.w
+++ b/Source/cerep/r-estmarA.w
@@ -449,7 +449,7 @@ DO:
      run windows/l-est.w (g_company,g_loc,focus:screen-value, output char-val).
 
      if char-val <> "" then do:                 
-            FIND FIRST eb WHERE string(RECID(eb)) = (char-val) NO-LOCK NO-ERROR.
+            FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR. 
             IF AVAIL eb THEN ASSIGN FOCUS:SCREEN-VALUE = eb.est-no
                                            lv-eb-tmpid = RECID(eb)    
                                 begin_est:SCREEN-VALUE = eb.est-no.
@@ -593,7 +593,7 @@ DO:
      run windows/l-est.w (g_company,g_loc,focus:screen-value, output char-val).
 
      if char-val <> "" then do:                 
-            FIND FIRST eb WHERE string(RECID(eb)) = (char-val) NO-LOCK NO-ERROR.
+            FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
             IF AVAIL eb THEN ASSIGN FOCUS:SCREEN-VALUE = eb.est-no
                                            lv-eb-tmpid = RECID(eb)    
                                   end_est:SCREEN-VALUE = eb.est-no.

--- a/Source/cerep/r-estmarN.w
+++ b/Source/cerep/r-estmarN.w
@@ -523,7 +523,7 @@ DO:
      run windows/l-est.w (g_company,g_loc,focus:screen-value, output char-val).
 
      if char-val <> "" then do:                 
-            FIND FIRST eb WHERE string(RECID(eb)) = (char-val) NO-LOCK NO-ERROR.
+         FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
             IF AVAIL eb THEN ASSIGN FOCUS:SCREEN-VALUE = eb.est-no
                                            lv-eb-tmpid = RECID(eb)    
                                 begin_est:SCREEN-VALUE = eb.est-no.
@@ -740,7 +740,7 @@ DO:
      run windows/l-est.w (g_company,g_loc,focus:screen-value, output char-val).
 
      if char-val <> "" then do:                 
-            FIND FIRST eb WHERE string(RECID(eb)) = (char-val) NO-LOCK NO-ERROR.
+         FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
             IF AVAIL eb THEN ASSIGN FOCUS:SCREEN-VALUE = eb.est-no
                                            lv-eb-tmpid = RECID(eb)    
                                   end_est:SCREEN-VALUE = eb.est-no.

--- a/Source/est/v-qthd.w
+++ b/Source/est/v-qthd.w
@@ -468,7 +468,7 @@ DO:
        WHEN "est-no" THEN DO:
               RUN windows/l-est.w (gcompany,gloc,quotehd.est-no:screen-value in frame {&frame-name}, OUTPUT char-val).
               IF char-val <> "" THEN DO:
-                 FIND FIRST eb WHERE STRING(RECID(eb)) = char-val NO-LOCK NO-ERROR.
+                  FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
                  IF AVAIL eb THEN DO:
                    quotehd.est-no:screen-value = eb.est-no.
                  END.

--- a/Source/est/w-finest.w
+++ b/Source/est/w-finest.w
@@ -356,7 +356,7 @@ DO:
       when "ls-est-no" then do:
               run windows/l-est.w (g_company,g_loc,lw-focus:screen-value, output char-val).
               if char-val <> "" then do:                 
-                 FIND FIRST eb WHERE string(RECID(eb)) = (char-val) NO-LOCK NO-ERROR.
+                  FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
                  IF AVAIL eb THEN ASSIGN lw-focus:SCREEN-VALUE = eb.est-no
                                          lv-eb-tmpid = RECID(eb)
                                   ls-cust-no:screen-value in frame {&frame-name} =  eb.cust-no

--- a/Source/jcrep/r-jcstdN.w
+++ b/Source/jcrep/r-jcstdN.w
@@ -530,7 +530,7 @@ ON HELP OF begin_est IN FRAME FRAME-A /* Beginning Estimate# */
 
         IF char-val <> "" THEN 
         DO:                 
-            FIND FIRST eb WHERE STRING(RECID(eb)) = (char-val) NO-LOCK NO-ERROR.
+            FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
             IF AVAILABLE eb THEN ASSIGN FOCUS:SCREEN-VALUE     = eb.est-no
                     lv-eb-tmpid            = RECID(eb)    
                     begin_est:SCREEN-VALUE = eb.est-no.
@@ -753,7 +753,7 @@ ON HELP OF end_est IN FRAME FRAME-A /* Ending Estimate# */
 
         IF char-val <> "" THEN 
         DO:                 
-            FIND FIRST eb WHERE STRING(RECID(eb)) = (char-val) NO-LOCK NO-ERROR.
+            FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
             IF AVAILABLE eb THEN ASSIGN FOCUS:SCREEN-VALUE   = eb.est-no
                     lv-eb-tmpid          = RECID(eb)    
                     end_est:SCREEN-VALUE = eb.est-no.

--- a/Source/oe/v-ord.w
+++ b/Source/oe/v-ord.w
@@ -980,7 +980,7 @@ DO:
          WHEN "est-no" THEN DO:
               RUN windows/l-est.w (g_company,g_loc,oe-ord.est-no:screen-value, OUTPUT char-val).
               IF char-val <> "" THEN DO:
-                 FIND FIRST eb WHERE STRING(RECID(eb)) = char-val NO-LOCK NO-ERROR.
+                  FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
                  IF AVAIL eb THEN DO:
                    oe-ord.est-no:screen-value = eb.est-no.
                    APPLY "value-changed" TO oe-ord.est-no.

--- a/Source/oe/v-ordl.w
+++ b/Source/oe/v-ordl.w
@@ -1632,7 +1632,7 @@ PROCEDURE display-est-detail :
   def var lv-pr-uom as cha no-undo.
   DEF VAR lv-qty AS DEC NO-UNDO.
 
-  find first eb where string(recid(eb)) = ip-char no-lock no-error.
+  FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(ip-char) NO-ERROR.
   if avail eb then do WITH FRAME {&Frame-name} :
      find first est-qty where est-qty.company = eb.company
                      and est-qty.est-no = eb.est-no

--- a/Source/po/VendCostExp.w
+++ b/Source/po/VendCostExp.w
@@ -502,7 +502,7 @@ DO:
 
            RUN windows/l-est.w (g_company,g_loc,"", OUTPUT char-val).
            IF char-val <> "" THEN DO:
-               FIND FIRST eb WHERE STRING(RECID(eb)) = char-val NO-LOCK NO-ERROR.
+               FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
                IF AVAIL eb THEN 
                    begin_est-no:screen-value = eb.est-no.
            END.
@@ -513,7 +513,7 @@ DO:
            ls-cur-val = lw-focus:screen-value.
            RUN windows/l-est.w (g_company,g_loc,"", OUTPUT char-val).
            IF char-val <> "" THEN DO:
-               FIND FIRST eb WHERE STRING(RECID(eb)) = char-val NO-LOCK NO-ERROR.
+               FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
                IF AVAIL eb THEN 
                    end_est-no:screen-value = eb.est-no.
            END.

--- a/Source/util/arch-est.w
+++ b/Source/util/arch-est.w
@@ -399,7 +399,7 @@ DO:
      run windows/l-est.w (g_company,g_loc,focus:screen-value, output char-val).
 
      if char-val <> "" then do:                 
-            FIND FIRST eb WHERE string(RECID(eb)) = (char-val) NO-LOCK NO-ERROR.
+         FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
             IF AVAIL eb THEN ASSIGN FOCUS:SCREEN-VALUE = eb.est-no
                                            lv-eb-tmpid = RECID(eb)    
                                 begin_est:SCREEN-VALUE = eb.est-no.
@@ -419,7 +419,7 @@ DO:
      run windows/l-est.w (g_company,g_loc,focus:screen-value, output char-val).
 
      if char-val <> "" then do:                 
-            FIND FIRST eb WHERE string(RECID(eb)) = (char-val) NO-LOCK NO-ERROR.
+         FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
             IF AVAIL eb THEN ASSIGN FOCUS:SCREEN-VALUE = eb.est-no
                                            lv-eb-tmpid = RECID(eb)    
                                   end_est:SCREEN-VALUE = eb.est-no.

--- a/Source/util/custmargin.w
+++ b/Source/util/custmargin.w
@@ -406,7 +406,7 @@ ON HELP OF begin_est IN FRAME FRAME-A /* Beginning Estimate# */
 
         IF char-val <> "" THEN 
         DO:                 
-            FIND FIRST eb WHERE STRING(RECID(eb)) = (char-val) NO-LOCK NO-ERROR.
+            FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
             IF AVAILABLE eb THEN ASSIGN FOCUS:SCREEN-VALUE     = eb.est-no
                     lv-eb-tmpid            = RECID(eb)    
                     begin_est:SCREEN-VALUE = eb.est-no.
@@ -512,7 +512,7 @@ ON HELP OF end_est IN FRAME FRAME-A /* Ending Estimate# */
 
         IF char-val <> "" THEN 
         DO:                 
-            FIND FIRST eb WHERE STRING(RECID(eb)) = (char-val) NO-LOCK NO-ERROR.
+            FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
             IF AVAILABLE eb THEN ASSIGN FOCUS:SCREEN-VALUE   = eb.est-no
                     lv-eb-tmpid          = RECID(eb)    
                     end_est:SCREEN-VALUE = eb.est-no.

--- a/Source/util/dev/fixceit1.w
+++ b/Source/util/dev/fixceit1.w
@@ -337,13 +337,13 @@ ASSIGN
      _Where[1]         = "eb.company eq cocode and
 eb.est-no  eq ls-est-no"
      _FldNameList[1]   > asi.eb.form-no
-"eb.form-no" "S#" ? "integer" ? ? ? ? ? ? no ? no no "4" yes no no "U" "" ""
+"eb.form-no" "S#" ? "integer" ? ? ? ? ? ? no ? no no "4" yes no no "U" "" "" "" "" "" "" 0 no 0 no no
      _FldNameList[2]   > asi.eb.blank-no
-"eb.blank-no" "B#" ? "integer" ? ? ? ? ? ? no ? no no "4" yes no no "U" "" ""
+"eb.blank-no" "B#" ? "integer" ? ? ? ? ? ? no ? no no "4" yes no no "U" "" "" "" "" "" "" 0 no 0 no no
      _FldNameList[3]   > asi.eb.part-no
-"eb.part-no" ? ? "character" ? ? ? ? ? ? no ? no no "23.2" yes no no "U" "" ""
+"eb.part-no" ? ? "character" ? ? ? ? ? ? no ? no no "23.2" yes no no "U" "" "" "" "" "" "" 0 no 0 no no
      _FldNameList[4]   > asi.eb.stock-no
-"eb.stock-no" "FG Item#" ? "character" ? ? ? ? ? ? yes ? no no "22" yes no no "U" "" ""
+"eb.stock-no" "FG Item#" ? "character" ? ? ? ? ? ? yes ? no no "22" yes no no "U" "" "" "" "" "" "" 0 no 0 no no
      _Query            is NOT OPENED
 */  /* BROWSE br_table */
 &ANALYZE-RESUME
@@ -376,7 +376,7 @@ DO:
       when "ls-est-no" then do:
               run windows/l-est.w (g_company,g_loc,focus:screen-value, output char-val).
               if char-val <> "" then do:                 
-                 FIND FIRST eb WHERE string(RECID(eb)) = (char-val) NO-LOCK NO-ERROR.
+                  FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
                  IF AVAIL eb THEN ASSIGN FOCUS:SCREEN-VALUE = eb.est-no
                                   ls-cust-no:screen-value in frame {&frame-name} =  eb.cust-no
                                   ls-est-no:SCREEN-VALUE = eb.est-no

--- a/Source/util/fixceit1.w
+++ b/Source/util/fixceit1.w
@@ -376,7 +376,7 @@ DO:
       when "ls-est-no" then do:
               run windows/l-est.w (g_company,g_loc,focus:screen-value, output char-val).
               if char-val <> "" then do:                 
-                 FIND FIRST eb WHERE string(RECID(eb)) = (char-val) NO-LOCK NO-ERROR.
+                  FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
                  IF AVAIL eb THEN ASSIGN FOCUS:SCREEN-VALUE = eb.est-no
                                   ls-cust-no:screen-value in frame {&frame-name} =  eb.cust-no
                                   ls-est-no:SCREEN-VALUE = eb.est-no

--- a/Source/util/updateestno.w
+++ b/Source/util/updateestno.w
@@ -185,7 +185,7 @@ DO:
      run windows/l-est.w (cocode,locode,focus:screen-value, output char-val).
               
      if char-val <> "" then do:                 
-        FIND FIRST eb WHERE string(RECID(eb)) = (char-val) NO-LOCK NO-ERROR.
+         FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
         IF AVAIL eb THEN ASSIGN FOCUS:SCREEN-VALUE = eb.est-no
                                        lv-eb-tmpid = RECID(eb)    
                             begin_est:SCREEN-VALUE = eb.est-no.

--- a/Source/viewers/vendcostmtx.w
+++ b/Source/viewers/vendcostmtx.w
@@ -423,7 +423,7 @@ DO:
          RUN windows/l-est.w (g_company,g_loc,vendItemCost.estimateNo:SCREEN-VALUE, OUTPUT char-val).
          IF char-val NE "" THEN DO:
              FIND FIRST eb NO-LOCK
-                  WHERE STRING(RECID(eb)) EQ char-val
+                  WHERE RECID(eb) EQ INT(char-val)
                   NO-ERROR.
              IF AVAILABLE eb THEN
              vendItemCost.estimateNo:screen-value = eb.est-no.

--- a/Source/viewers/vendcostres.w
+++ b/Source/viewers/vendcostres.w
@@ -730,7 +730,7 @@ DO:
         
          RUN windows/l-est.w (g_company,g_loc,vendItemCost.estimateNo:screen-value, OUTPUT char-val).
          IF char-val <> "" THEN DO:
-             FIND FIRST eb WHERE STRING(RECID(eb)) = char-val NO-LOCK NO-ERROR.
+             FIND FIRST eb NO-LOCK WHERE RECID(eb) = INT(char-val) NO-ERROR.
              IF AVAIL eb THEN 
                  vendItemCost.estimateNo:screen-value = eb.est-no.
          END.


### PR DESCRIPTION
Removed all constructs with syntax like "FIND x WHERE STRING(RECID(x)) EQ char-val and replaced with FIND x WHERE RECID(x) EQ INT(char-val)
preventing whole-table indexing for thiese finds
Almost all occurred when returning from F1 lookup on est-no field, but also occured when displaying/saving an order-line
Files changed:
 4  Source/browsers/mailcont.w 
 2  Source/browsers/vendcostmtx.w 
 4  Source/cerep/r-estA.w 
 4  Source/cerep/r-estN.w 
 4  Source/cerep/r-estmarA.w 
 4  Source/cerep/r-estmarN.w 
 2  Source/est/v-qthd.w 
 2  Source/est/w-finest.w 
 4  Source/jcrep/r-jcstdN.w 
 2  Source/oe/v-ord.w 
 2  Source/oe/v-ordl.w 
 4  Source/po/VendCostExp.w 
 4  Source/util/arch-est.w 
 4  Source/util/custmargin.w 
 10  Source/util/dev/fixceit1.w 
 2  Source/util/fixceit1.w 
 2  Source/util/updateestno.w 
 2  Source/viewers/vendcostmtx.w 
 2  Source/viewers/vendcostres.w 
