### PR TITLE
Ticekt 59335 IR2 / FG Value is wrong because an adjustment made in I-…U-3 does not set UOM59335 IR2 / FG Value is wrong because an adjustment made in I-U-3 does not set UOM:

### DIFF
--- a/Source/fg/b-fgadj.w
+++ b/Source/fg/b-fgadj.w
@@ -977,7 +977,7 @@ PROCEDURE local-assign-statement :
 
   /* Code placed here will execute AFTER standard behavior.    */
   ASSIGN BROWSE {&browse-name} fg-rctd.t-qty fg-rctd.ext-cost.
-  fg-rctd.cost-uom = lv-uom.
+  fg-rctd.pur-uom = lv-uom.
 
 END PROCEDURE.
 


### PR DESCRIPTION
Files:
fg/b-fgadj.w