### PR TITLE
62601 OR6- Incorrect Cost on Report

### DIFF
--- a/Source/oe/rep/sa-comm.i
+++ b/Source/oe/rep/sa-comm.i
@@ -603,6 +603,27 @@
              v-gp      = round(v-prof / v-amt * 100,2) .
              if v-gp   eq ? then v-gp   = 0.
      END.
+    /* IF the full cost in the ar-invl has been set to zero, get the full cost from the itemfg record */
+    ELSE IF v-full-cost EQ YES AND ar-invl.spare-dec-1 EQ 0 THEN DO:
+        FIND c-itemfg NO-LOCK WHERE 
+            c-itemfg.company EQ ar-invl.company AND 
+            c-itemfg.i-no EQ ar-invl.i-no 
+            NO-ERROR.
+        IF AVAIL c-itemfg 
+            AND c-itemfg.spare-dec-1 NE 0 THEN 
+        DO:
+            IF ar-invl.dscr[1] EQ "M" OR
+                ar-invl.dscr[1] EQ "" THEN
+                v-cost = c-itemfg.spare-dec-1 * (ar-invl.inv-qty / 1000) * v-slsp[1] / 100.
+            ELSE /*EA*/
+                v-cost = c-itemfg.spare-dec-1 * ar-invl.inv-qty * v-slsp[1] / 100.
+     
+            v-prof    = v-amt - v-cost.
+            IF v-prof EQ ? THEN v-prof = 0.
+            v-gp      = round(v-prof / v-amt * 100,2) .
+            if v-gp   eq ? then v-gp   = 0.
+        END.
+    END. 
         
 
       if not v-sumdet then DO:

--- a/Source/oe/rep/sa-comm.i
+++ b/Source/oe/rep/sa-comm.i
@@ -589,7 +589,9 @@
       v-part-fg = IF rd_part-fg BEGINS "Cust" THEN v-cust-part ELSE v-i-no.
 
     /* If 'full cost' selected and history full cost > zero, then print history full cost. */
-    IF v-full-cost THEN DO:
+        ASSIGN
+            deUseCost = 0.
+        IF v-full-cost THEN DO:
         IF ar-invl.spare-dec-1 GT 0 THEN ASSIGN 
             deUseCost = ar-invl.spare-dec-1.
         ELSE DO:

--- a/Source/oe/rep/sa-comm.i
+++ b/Source/oe/rep/sa-comm.i
@@ -588,42 +588,28 @@
 
       v-part-fg = IF rd_part-fg BEGINS "Cust" THEN v-cust-part ELSE v-i-no.
 
-     /* If 'full cost' selected and history full cost > zero, 
-        then print history full cost. */
-     IF v-full-cost = YES AND ar-invl.spare-dec-1 > 0 THEN DO:
-/*          ASSIGN v-cost = ar-invl.spare-dec-1. */
-         IF ar-invl.dscr[1] EQ "M" OR
-            ar-invl.dscr[1] EQ "" THEN
-             v-cost = ar-invl.spare-dec-1 * (ar-invl.inv-qty / 1000) * v-slsp[1] / 100.
-         ELSE /*EA*/
-             v-cost = ar-invl.spare-dec-1 * ar-invl.inv-qty * v-slsp[1] / 100.
-
-             v-prof    = v-amt - v-cost.
-             IF v-prof EQ ? THEN v-prof = 0.
-             v-gp      = round(v-prof / v-amt * 100,2) .
-             if v-gp   eq ? then v-gp   = 0.
-     END.
-    /* IF the full cost in the ar-invl has been set to zero, get the full cost from the itemfg record */
-    ELSE IF v-full-cost EQ YES AND ar-invl.spare-dec-1 EQ 0 THEN DO:
-        FIND c-itemfg NO-LOCK WHERE 
-            c-itemfg.company EQ ar-invl.company AND 
-            c-itemfg.i-no EQ ar-invl.i-no 
-            NO-ERROR.
-        IF AVAIL c-itemfg 
-            AND c-itemfg.spare-dec-1 NE 0 THEN 
-        DO:
-            IF ar-invl.dscr[1] EQ "M" OR
-                ar-invl.dscr[1] EQ "" THEN
-                v-cost = c-itemfg.spare-dec-1 * (ar-invl.inv-qty / 1000) * v-slsp[1] / 100.
-            ELSE /*EA*/
-                v-cost = c-itemfg.spare-dec-1 * ar-invl.inv-qty * v-slsp[1] / 100.
-     
-            v-prof    = v-amt - v-cost.
-            IF v-prof EQ ? THEN v-prof = 0.
-            v-gp      = round(v-prof / v-amt * 100,2) .
-            if v-gp   eq ? then v-gp   = 0.
+    /* If 'full cost' selected and history full cost > zero, then print history full cost. */
+    IF v-full-cost THEN DO:
+        IF ar-invl.spare-dec-1 GT 0 THEN ASSIGN 
+            deUseCost = ar-invl.spare-dec-1.
+        ELSE DO:
+            FIND c-itemfg NO-LOCK WHERE 
+                c-itemfg.company EQ ar-invl.company AND 
+                c-itemfg.i-no EQ ar-invl.i-no 
+                NO-ERROR.
+            IF AVAIL c-itemfg THEN ASSIGN 
+                deUseCost = c-itemfg.spare-dec-1.
         END.
-    END. 
+        IF ar-invl.dscr[1] EQ "M" 
+        OR ar-invl.dscr[1] EQ "" THEN ASSIGN 
+            v-cost = deUseCost * (ar-invl.inv-qty / 1000) * v-slsp[1] / 100.
+        ELSE ASSIGN /* EA */
+            v-cost = deUseCost * ar-invl.inv-qty * v-slsp[1] / 100
+            v-prof = v-amt - v-cost
+            v-prof = IF v-prof EQ ? THEN 0 ELSE v-prof
+            v-gp   = ROUND(v-prof / v-amt * 100,2)
+            v-gp    IF v-gp EQ ? 0 ELSE v-gp.
+    END.
         
 
       if not v-sumdet then DO:

--- a/Source/oe/rep/sa-commN.i
+++ b/Source/oe/rep/sa-commN.i
@@ -574,6 +574,8 @@
     /*  v-part-fg = IF rd_part-fg BEGINS "Cust" THEN v-cust-part ELSE v-i-no.*/
 
      /* If 'full cost' selected and history full cost > zero, then print history full cost. */
+     ASSIGN
+        deUseCost = 0.
      IF v-full-cost THEN DO:
          IF ar-invl.spare-dec-1 GT 0 THEN ASSIGN 
             deUseCost = ar-invl.spare-dec-1.

--- a/Source/oe/rep/sa-commN.i
+++ b/Source/oe/rep/sa-commN.i
@@ -573,42 +573,28 @@
 
     /*  v-part-fg = IF rd_part-fg BEGINS "Cust" THEN v-cust-part ELSE v-i-no.*/
 
-     /* If 'full cost' selected and history full cost > zero, 
-        then print history full cost. */
-     IF v-full-cost = YES AND ar-invl.spare-dec-1 > 0 THEN DO:
-/*          ASSIGN v-cost = ar-invl.spare-dec-1. */
-         IF ar-invl.dscr[1] EQ "M" OR
-            ar-invl.dscr[1] EQ "" THEN
-             v-cost = ar-invl.spare-dec-1 * (ar-invl.inv-qty / 1000) * v-slsp[1] / 100.
-         ELSE /*EA*/
-             v-cost = ar-invl.spare-dec-1 * ar-invl.inv-qty * v-slsp[1] / 100.
-             
-             v-prof    = v-amt - v-cost.
-             IF v-prof EQ ? THEN v-prof = 0.
-             v-gp      = round(v-prof / v-amt * 100,2) .
-             if v-gp   eq ? then v-gp   = 0.
-     END.
-     /* IF the full cost in the ar-invl has been set to zero, get the full cost from the itemfg record */
-     ELSE IF v-full-cost EQ YES AND ar-invl.spare-dec-1 EQ 0 THEN DO:
-         FIND c-itemfg NO-LOCK WHERE 
-            c-itemfg.company EQ ar-invl.company AND 
-            c-itemfg.i-no EQ ar-invl.i-no 
-            NO-ERROR.
-         IF AVAIL c-itemfg 
-         AND c-itemfg.spare-dec-1 NE 0 THEN DO:
-             IF ar-invl.dscr[1] EQ "M" OR
-                 ar-invl.dscr[1] EQ "" THEN
-                 v-cost = c-itemfg.spare-dec-1 * (ar-invl.inv-qty / 1000) * v-slsp[1] / 100.
-             ELSE /*EA*/
-                 v-cost = c-itemfg.spare-dec-1 * ar-invl.inv-qty * v-slsp[1] / 100.
-             
-             v-prof    = v-amt - v-cost.
-             IF v-prof EQ ? THEN v-prof = 0.
-             v-gp      = round(v-prof / v-amt * 100,2) .
-             if v-gp   eq ? then v-gp   = 0.
+     /* If 'full cost' selected and history full cost > zero, then print history full cost. */
+     IF v-full-cost THEN DO:
+         IF ar-invl.spare-dec-1 GT 0 THEN ASSIGN 
+            deUseCost = ar-invl.spare-dec-1.
+         ELSE DO:
+             FIND c-itemfg NO-LOCK WHERE 
+                 c-itemfg.company EQ ar-invl.company AND 
+                 c-itemfg.i-no EQ ar-invl.i-no 
+                 NO-ERROR.
+             IF AVAIL c-itemfg THEN ASSIGN 
+                deUseCost = c-itemfg.spare-dec-1.
          END.
-     END. 
-        
+         IF ar-invl.dscr[1] EQ "M" 
+         OR ar-invl.dscr[1] EQ "" THEN ASSIGN 
+             v-cost = deUseCost * (ar-invl.inv-qty / 1000) * v-slsp[1] / 100.
+         ELSE ASSIGN /* EA */
+             v-cost = deUseCost * ar-invl.inv-qty * v-slsp[1] / 100
+             v-prof = v-amt - v-cost
+             v-prof = IF v-prof EQ ? THEN 0 ELSE v-prof
+             v-gp   = ROUND(v-prof / v-amt * 100,2)
+             v-gp    IF v-gp EQ ? 0 ELSE v-gp.
+     END.
 
      /* if not v-sumdet then DO:
          display tt-report.key-01       when first-of(tt-report.key-01)

--- a/Source/oe/rep/sa-commN.i
+++ b/Source/oe/rep/sa-commN.i
@@ -588,6 +588,26 @@
              v-gp      = round(v-prof / v-amt * 100,2) .
              if v-gp   eq ? then v-gp   = 0.
      END.
+     /* IF the full cost in the ar-invl has been set to zero, get the full cost from the itemfg record */
+     ELSE IF v-full-cost EQ YES AND ar-invl.spare-dec-1 EQ 0 THEN DO:
+         FIND c-itemfg NO-LOCK WHERE 
+            c-itemfg.company EQ ar-invl.company AND 
+            c-itemfg.i-no EQ ar-invl.i-no 
+            NO-ERROR.
+         IF AVAIL c-itemfg 
+         AND c-itemfg.spare-dec-1 NE 0 THEN DO:
+             IF ar-invl.dscr[1] EQ "M" OR
+                 ar-invl.dscr[1] EQ "" THEN
+                 v-cost = c-itemfg.spare-dec-1 * (ar-invl.inv-qty / 1000) * v-slsp[1] / 100.
+             ELSE /*EA*/
+                 v-cost = c-itemfg.spare-dec-1 * ar-invl.inv-qty * v-slsp[1] / 100.
+             
+             v-prof    = v-amt - v-cost.
+             IF v-prof EQ ? THEN v-prof = 0.
+             v-gp      = round(v-prof / v-amt * 100,2) .
+             if v-gp   eq ? then v-gp   = 0.
+         END.
+     END. 
         
 
      /* if not v-sumdet then DO:

--- a/Source/oerep/r-commsA.w
+++ b/Source/oerep/r-commsA.w
@@ -52,6 +52,7 @@ def var v-cost1     as   char.
 def var v-year      as   integer.
 DEF VAR v-calc-cat  AS   CHAR.
 DEF VAR cSlsList AS CHAR NO-UNDO.
+DEF VAR deUseCost   AS DEC NO-UNDO.
 
 DEF BUFFER b-itemfg FOR itemfg.
 DEF BUFFER c-itemfg FOR itemfg.

--- a/Source/oerep/r-commsA.w
+++ b/Source/oerep/r-commsA.w
@@ -54,6 +54,7 @@ DEF VAR v-calc-cat  AS   CHAR.
 DEF VAR cSlsList AS CHAR NO-UNDO.
 
 DEF BUFFER b-itemfg FOR itemfg.
+DEF BUFFER c-itemfg FOR itemfg.
 
 def TEMP-TABLE w-comm    no-undo
     FIELD sman    as   char

--- a/Source/oerep/r-commsN.w
+++ b/Source/oerep/r-commsN.w
@@ -52,6 +52,7 @@ def var v-cost1     as   char.
 def var v-year      as   integer.
 DEF VAR v-calc-cat  AS   CHAR.
 DEF VAR cSlsList AS CHAR NO-UNDO.
+DEF VAR deUseCost   AS DEC NO-UNDO.
 
 DEF BUFFER b-itemfg FOR itemfg.
 DEF BUFFER c-itemfg FOR itemfg.

--- a/Source/oerep/r-commsN.w
+++ b/Source/oerep/r-commsN.w
@@ -54,6 +54,7 @@ DEF VAR v-calc-cat  AS   CHAR.
 DEF VAR cSlsList AS CHAR NO-UNDO.
 
 DEF BUFFER b-itemfg FOR itemfg.
+DEF BUFFER c-itemfg FOR itemfg.
 
 def TEMP-TABLE w-comm    no-undo
     FIELD sman    as   char


### PR DESCRIPTION
files changed:
oe/rep/sa-comm.i - added failover logic if ar-invl.spare-dec-1 (total-cost) has been reset to zero, find itemfg and get cost from there
oe/rep/sa-commN.i - added failover logic if ar-invl.spare-dec-1 (total-cost) has been reset to zero, find itemfg and get cost from there
oerep/r-commsA.w - added buffer to ensure unique itemfg record
oerep/r-commsN.w - added buffer to ensure unique itemfg record