### PR TITLE
62601 - OR6 incorrect cost on report

### DIFF
--- a/Source/oe/rep/sa-comm.i
+++ b/Source/oe/rep/sa-comm.i
@@ -345,7 +345,7 @@
             IF AVAIL oe-boll THEN cWhse = oe-boll.loc.
         END.
 
-        IF ar-invl.t-cost NE 0 THEN
+        IF ar-invl.t-cost NE 0 THEN           
              v-cost = ar-invl.t-cost * v-slsp[1] / 100.
           
         /*when updating cost via A-U-1, bug where t-cost
@@ -589,11 +589,11 @@
       v-part-fg = IF rd_part-fg BEGINS "Cust" THEN v-cust-part ELSE v-i-no.
 
     /* If 'full cost' selected and history full cost > zero, then print history full cost. */
-        ASSIGN
+    IF v-full-cost THEN DO:
+        ASSIGN 
             deUseCost = 0.
-        IF v-full-cost THEN DO:
         IF ar-invl.spare-dec-1 GT 0 THEN ASSIGN 
-            v-cost = ar-invl.spare-dec-1.
+            deUseCost = ar-invl.spare-dec-1.
         ELSE DO:
             FIND c-itemfg NO-LOCK WHERE 
                 c-itemfg.company EQ ar-invl.company AND 
@@ -601,14 +601,16 @@
                 NO-ERROR.
             IF AVAIL c-itemfg 
             AND c-itemfg.spare-dec-1 NE 0 THEN ASSIGN 
-                v-cost = c-itemfg.spare-dec-1.
+                deUseCost = c-itemfg.spare-dec-1.
         END.
         IF ar-invl.dscr[1] EQ "M" 
         OR ar-invl.dscr[1] EQ "" THEN ASSIGN 
-            v-cost = v-cost * (ar-invl.inv-qty / 1000) * v-slsp[1] / 100.
+            deUseCost = deUseCost * (ar-invl.inv-qty / 1000) * v-slsp[1] / 100.
         ELSE ASSIGN  /* EA */ 
-            v-cost = v-cost * ar-invl.inv-qty * v-slsp[1] / 100
-            v-prof = v-amt - v-cost
+            deUseCost = deUseCost * ar-invl.inv-qty * v-slsp[1] / 100.
+        ASSIGN 
+            v-cost = deUseCost
+            v-prof = v-amt - deUseCost
             v-prof = IF v-prof EQ ? THEN 0 ELSE v-prof
             v-gp   = ROUND(v-prof / v-amt * 100 , 2)
             v-gp   = IF v-gp EQ ? THEN 0 ELSE v-gp. 

--- a/Source/oe/rep/sa-comm.i
+++ b/Source/oe/rep/sa-comm.i
@@ -606,7 +606,7 @@
         END.
         IF ar-invl.dscr[1] EQ "M" 
         OR ar-invl.dscr[1] EQ "" 
-        OR AVAIL c-itemfg AND c-itemfg.prod-uom EQ "M" THEN ASSIGN 
+        OR (AVAIL c-itemfg AND c-itemfg.prod-uom EQ "M") THEN ASSIGN 
             deUseCost = deUseCost * (ar-invl.inv-qty / 1000) * v-slsp[1] / 100.
         ELSE ASSIGN  /* EA */ 
             deUseCost = deUseCost * ar-invl.inv-qty * v-slsp[1] / 100.

--- a/Source/oe/rep/sa-comm.i
+++ b/Source/oe/rep/sa-comm.i
@@ -594,7 +594,8 @@
             deUseCost = 0.
         IF ar-invl.spare-dec-1 GT 0 THEN ASSIGN 
             deUseCost = ar-invl.spare-dec-1.
-        ELSE DO:
+        ELSE 
+        DO:
             FIND c-itemfg NO-LOCK WHERE 
                 c-itemfg.company EQ ar-invl.company AND 
                 c-itemfg.i-no EQ ar-invl.i-no 
@@ -604,7 +605,8 @@
                 deUseCost = c-itemfg.spare-dec-1.
         END.
         IF ar-invl.dscr[1] EQ "M" 
-        OR ar-invl.dscr[1] EQ "" THEN ASSIGN 
+        OR ar-invl.dscr[1] EQ "" 
+        OR AVAIL c-itemfg AND c-itemfg.prod-uom EQ "M" THEN ASSIGN 
             deUseCost = deUseCost * (ar-invl.inv-qty / 1000) * v-slsp[1] / 100.
         ELSE ASSIGN  /* EA */ 
             deUseCost = deUseCost * ar-invl.inv-qty * v-slsp[1] / 100.

--- a/Source/oe/rep/sa-commN.i
+++ b/Source/oe/rep/sa-commN.i
@@ -578,21 +578,22 @@
             ASSIGN 
                 deUseCost = 0.
             IF ar-invl.spare-dec-1 GT 0 THEN ASSIGN 
-                    deUseCost = ar-invl.spare-dec-1.
+                deUseCost = ar-invl.spare-dec-1.
             ELSE DO:
                 FIND c-itemfg NO-LOCK WHERE 
                     c-itemfg.company EQ ar-invl.company AND 
                     c-itemfg.i-no EQ ar-invl.i-no 
                     NO-ERROR.
                 IF AVAIL c-itemfg 
-                    AND c-itemfg.spare-dec-1 NE 0 THEN ASSIGN 
-                        deUseCost = c-itemfg.spare-dec-1.
+                AND c-itemfg.spare-dec-1 NE 0 THEN ASSIGN 
+                    deUseCost = c-itemfg.spare-dec-1.
             END.
             IF ar-invl.dscr[1] EQ "M" 
-                OR ar-invl.dscr[1] EQ "" THEN ASSIGN 
-                    deUseCost = deUseCost * (ar-invl.inv-qty / 1000) * v-slsp[1] / 100.
+            OR ar-invl.dscr[1] EQ "" 
+            OR AVAIL c-itemfg AND c-itemfg.prod-uom EQ "M" THEN ASSIGN 
+                deUseCost = deUseCost * (ar-invl.inv-qty / 1000) * v-slsp[1] / 100.
             ELSE ASSIGN  /* EA */ 
-                    deUseCost = deUseCost * ar-invl.inv-qty * v-slsp[1] / 100.
+                deUseCost = deUseCost * ar-invl.inv-qty * v-slsp[1] / 100.
             ASSIGN 
                 v-cost = deUseCost
                 v-prof = v-amt - deUseCost

--- a/Source/oe/rep/sa-commN.i
+++ b/Source/oe/rep/sa-commN.i
@@ -590,7 +590,7 @@
             END.
             IF ar-invl.dscr[1] EQ "M" 
             OR ar-invl.dscr[1] EQ "" 
-            OR AVAIL c-itemfg AND c-itemfg.prod-uom EQ "M" THEN ASSIGN 
+            OR (AVAIL c-itemfg AND c-itemfg.prod-uom EQ "M") THEN ASSIGN 
                 deUseCost = deUseCost * (ar-invl.inv-qty / 1000) * v-slsp[1] / 100.
             ELSE ASSIGN  /* EA */ 
                 deUseCost = deUseCost * ar-invl.inv-qty * v-slsp[1] / 100.

--- a/Source/oe/rep/sa-commN.i
+++ b/Source/oe/rep/sa-commN.i
@@ -571,33 +571,35 @@
       
       {sys/inc/roundup.i v-qty}
 
-    /*  v-part-fg = IF rd_part-fg BEGINS "Cust" THEN v-cust-part ELSE v-i-no.*/
+        /*  v-part-fg = IF rd_part-fg BEGINS "Cust" THEN v-cust-part ELSE v-i-no.*/
 
-     /* If 'full cost' selected and history full cost > zero, then print history full cost. */
-     ASSIGN
-        deUseCost = 0.
-     IF v-full-cost THEN DO:
-         IF ar-invl.spare-dec-1 GT 0 THEN ASSIGN 
-            v-cost = ar-invl.spare-dec-1.
-         ELSE DO:
-             FIND c-itemfg NO-LOCK WHERE 
-                 c-itemfg.company EQ ar-invl.company AND 
-                 c-itemfg.i-no EQ ar-invl.i-no 
-                 NO-ERROR.
-             IF AVAIL c-itemfg 
-             AND c-itemfg.spare-dec-1 NE 0 THEN ASSIGN 
-                v-cost = c-itemfg.spare-dec-1.
-         END.
-         IF ar-invl.dscr[1] EQ "M" 
-         OR ar-invl.dscr[1] EQ "" THEN ASSIGN 
-             v-cost = v-cost * (ar-invl.inv-qty / 1000) * v-slsp[1] / 100.
-         ELSE ASSIGN /* EA */
-             v-cost = v-cost * ar-invl.inv-qty * v-slsp[1] / 100
-             v-prof = v-amt - v-cost
-             v-prof = IF v-prof EQ ? THEN 0 ELSE v-prof
-             v-gp   = ROUND(v-prof / v-amt * 100,2)
-             v-gp   = IF v-gp EQ ? THEN 0 ELSE v-gp.
-     END.
+        /* If 'full cost' selected and history full cost > zero, then print history full cost. */
+        IF v-full-cost THEN DO:
+            ASSIGN 
+                deUseCost = 0.
+            IF ar-invl.spare-dec-1 GT 0 THEN ASSIGN 
+                    deUseCost = ar-invl.spare-dec-1.
+            ELSE DO:
+                FIND c-itemfg NO-LOCK WHERE 
+                    c-itemfg.company EQ ar-invl.company AND 
+                    c-itemfg.i-no EQ ar-invl.i-no 
+                    NO-ERROR.
+                IF AVAIL c-itemfg 
+                    AND c-itemfg.spare-dec-1 NE 0 THEN ASSIGN 
+                        deUseCost = c-itemfg.spare-dec-1.
+            END.
+            IF ar-invl.dscr[1] EQ "M" 
+                OR ar-invl.dscr[1] EQ "" THEN ASSIGN 
+                    deUseCost = deUseCost * (ar-invl.inv-qty / 1000) * v-slsp[1] / 100.
+            ELSE ASSIGN  /* EA */ 
+                    deUseCost = deUseCost * ar-invl.inv-qty * v-slsp[1] / 100.
+            ASSIGN 
+                v-cost = deUseCost
+                v-prof = v-amt - deUseCost
+                v-prof = IF v-prof EQ ? THEN 0 ELSE v-prof
+                v-gp   = ROUND(v-prof / v-amt * 100 , 2)
+                v-gp   = IF v-gp EQ ? THEN 0 ELSE v-gp. 
+        END.
 
      /* if not v-sumdet then DO:
          display tt-report.key-01       when first-of(tt-report.key-01)


### PR DESCRIPTION
programs changed:
oe/rep/sa-comm.i
oe/rep/sa-commN.i
In both programs, if ar-invl.t-cost had been populated, then the "base" cost in the report was using the total line cost, rather than the "per unit" cost, causing a doubling of cost in the report (cost * qty * qty).  This change should resolve that issue.