### PR TITLE
64876 Passwords stored in plain text in database

### DIFF
--- a/Deployment/BuildScript/ToCompile/asiUpdateEnv.w
+++ b/Deployment/BuildScript/ToCompile/asiUpdateEnv.w
@@ -3066,7 +3066,13 @@ PROCEDURE ipDataFix200100:
         ASSIGN 
             sys-ctrl.log-fld = TRUE.
     END. 
-
+    
+    /* 64876 - Encrypt passwords in userPwdHist */
+    FOR EACH userPwdHist:
+        ASSIGN 
+            userPwdHist.pwd = ENCODE(userPwdHist.pwd).
+    END.
+            
 END PROCEDURE.
 	
 /* _UIB-CODE-BLOCK-END */

--- a/Deployment/BuildScript/ToCompile/asiUpdateEnv.w
+++ b/Deployment/BuildScript/ToCompile/asiUpdateEnv.w
@@ -3072,6 +3072,14 @@ PROCEDURE ipDataFix200100:
         ASSIGN 
             userPwdHist.pwd = ENCODE(userPwdHist.pwd).
     END.
+    
+    /* 64885 - Load inventoryStatusType data */
+    INPUT FROM VALUE(cUpdDataDir + "\inventoryStatusType.d") NO-ECHO.
+    REPEAT:
+        CREATE inventoryStatusType.
+        IMPORT inventoryStatusType.
+    END.
+    
             
 END PROCEDURE.
 	

--- a/Deployment/BuildScript/buildDumpFiles.p
+++ b/Deployment/BuildScript/buildDumpFiles.p
@@ -211,3 +211,9 @@ FOR EACH {&cFile}:
 END.
 OUTPUT CLOSE.
 
+&SCOPED-DEFINE cFile inventoryStatusType
+OUTPUT TO VALUE(cOutDir + "\{&cFile}.d").
+FOR EACH {&cFile}:
+    EXPORT {&cFile}.
+END.
+OUTPUT CLOSE.

--- a/Source/viewers/users.w
+++ b/Source/viewers/users.w
@@ -1466,7 +1466,7 @@ PROCEDURE ipChangePassword :
         BUFFER-COPY tempUser EXCEPT _tenantid TO _User.
         FIND FIRST userPwdHist EXCLUSIVE WHERE
             userPwdHist.user_id = _user._userID AND
-            userPwdHist.pwd = cNewPassword AND
+            userPwdHist.pwd = ENCODE(cNewPassword) AND
             userPwdHist.pwdDate = today NO-ERROR.
         IF NOT AVAIL userPwdHist THEN DO:
             CREATE userPwdHist.
@@ -1478,7 +1478,7 @@ PROCEDURE ipChangePassword :
                 userPwdHist.createUser = USERID(LDBNAME(1)).
         END.
         ASSIGN
-            userPwdHist.pwd = cNewPassword
+            userPwdHist.pwd = ENCODE(cNewPassword)
             userPwdHist.updateDate = TODAY
             userPwdHist.updateTime = TIME
             userPwdHist.updateUser = USERID(LDBNAME(1))


### PR DESCRIPTION
Files changed:
asiUpdateEnv.w - encode all pwd fields in userPwdHist if version LT 20.01.00
viewers/users.w - encode pwd field when writing to userPwdHist