### PR TITLE
62968 EDI - Tri-Lakes (Welch)

### DIFF
--- a/Source/po/po-gpexp.p
+++ b/Source/po/po-gpexp.p
@@ -4,95 +4,100 @@
 /*                                                                            */
 /* -------------------------------------------------------------------------- */
 
-DEF INPUT PARAM v-format AS CHAR NO-UNDO.
+DEFINE INPUT PARAMETER v-format AS CHARACTER NO-UNDO.
 
 {sys/inc/var.i SHARED}
 {sys/form/s-top.f}
 
-DEF BUFFER xjob-mat FOR job-mat.
-DEF BUFFER xitem    FOR item.
-DEF BUFFER b-ref1   FOR reftable.
-DEF BUFFER b-ref2   FOR reftable.
+DEFINE BUFFER xjob-mat FOR job-mat.
+DEFINE BUFFER xitem    FOR item.
+DEFINE BUFFER b-ref1   FOR reftable.
+DEFINE BUFFER b-ref2   FOR reftable.
 
 {po/po-print.i}
 
-DEF VAR v-sname LIKE shipto.ship-name.
-DEF VAR v-saddr LIKE shipto.ship-addr.
-DEF VAR v-scity LIKE shipto.ship-city.
-DEF VAR v-sstate LIKE shipto.ship-state.
-DEF VAR v-szip LIKE shipto.ship-zip.
-DEF VAR v-adder LIKE item.i-no EXTENT 6 NO-UNDO.
-DEF VAR xg-flag AS LOG INIT NO NO-UNDO.
-DEF VAR v-instr AS CHAR NO-UNDO.
-DEF VAR v-ord-qty LIKE po-ordl.ord-qty NO-UNDO.
-DEF VAR v-ord-cst LIKE po-ordl.cost NO-UNDO.
-DEF VAR v-outfile AS CHAR EXTENT 4 NO-UNDO.
-DEF VAR v-mach AS CHAR EXTENT 4 NO-UNDO.
-DEF VAR v-line AS CHAR NO-UNDO.
-DEF VAR v-char AS CHAR NO-UNDO.
-DEF VAR ll-scored AS LOG NO-UNDO.
-DEF STREAM sOut.
-DEF VAR cInLn AS CHAR NO-UNDO.
+DEFINE VARIABLE v-sname LIKE shipto.ship-name.
+DEFINE VARIABLE v-saddr LIKE shipto.ship-addr.
+DEFINE VARIABLE v-scity LIKE shipto.ship-city.
+DEFINE VARIABLE v-sstate LIKE shipto.ship-state.
+DEFINE VARIABLE v-szip LIKE shipto.ship-zip.
+DEFINE VARIABLE v-adder LIKE item.i-no EXTENT 6 NO-UNDO.
+DEFINE VARIABLE xg-flag AS LOG INIT NO NO-UNDO.
+DEFINE VARIABLE v-instr AS CHARACTER NO-UNDO.
+DEFINE VARIABLE v-ord-qty LIKE po-ordl.ord-qty NO-UNDO.
+DEFINE VARIABLE v-ord-cst LIKE po-ordl.cost NO-UNDO.
+DEFINE VARIABLE v-outfile AS CHARACTER EXTENT 4 NO-UNDO.
+DEFINE VARIABLE v-mach AS CHARACTER EXTENT 4 NO-UNDO.
+DEFINE VARIABLE v-line AS CHARACTER NO-UNDO.
+DEFINE VARIABLE v-char AS CHARACTER NO-UNDO.
+DEFINE VARIABLE ll-scored AS LOG NO-UNDO.
+DEFINE STREAM sOut.
+DEFINE VARIABLE cInLn AS CHARACTER NO-UNDO.
+DEFINE VARIABLE lUseNew AS LOG NO-UNDO.
 
-DEF TEMP-TABLE tt-score NO-UNDO 
-    FIELD tt-seq  AS INT
-    FIELD tt-scor AS DEC
-    FIELD tt-type AS CHAR
+DEFINE TEMP-TABLE tt-score NO-UNDO 
+    FIELD tt-seq  AS INTEGER
+    FIELD tt-scor AS DECIMAL
+    FIELD tt-type AS CHARACTER
     INDEX tt-seq tt-seq.
     
 DEFINE TEMP-TABLE sheetorder NO-UNDO
     BEFORE-TABLE sheetorderBef
-	    FIELD customerpo AS INT
-        FIELD canonicalfile AS CHAR
-        FIELD purchasedby AS CHAR
-        FIELD plantid AS CHAR 
-        FIELD billto AS CHAR
-        FIELD ordernotes AS CHAR 
-        INDEX customerpo IS PRIMARY UNIQUE customerpo
-          .
+    FIELD customerpo AS INTEGER
+    FIELD canonicalfile AS CHARACTER
+    FIELD purchasedby AS CHARACTER
+    FIELD plantid AS CHARACTER 
+    FIELD billto AS CHARACTER
+/*    FIELD ordernotes AS CHARACTER*/
+    INDEX customerpo IS PRIMARY UNIQUE customerpo
+    .
 
 /* Definition for Temp-Table detailline */
 DEFINE TEMP-TABLE detailline
     BEFORE-TABLE detaillineBef
-        FIELD customerpo AS INT
-        FIELD lineNo AS INT
-        FIELD shipto AS CHAR
-        FIELD shiptoaddress AS CHAR
-        FIELD customerponbr AS CHAR
-        FIELD customerpolineseqnbr AS CHAR
-        FIELD internalprodno AS CHAR
-        FIELD custitemname AS CHAR
-        FIELD custitemdscr1 AS CHAR
-        FIELD custitemdscr2 AS CHAR
-        FIELD quantityordered AS DEC
-        FIELD uom AS CHAR
-        FIELD duedate AS CHAR
-        FIELD duetime AS CHAR
-        FIELD currentdatetime AS CHAR
-        FIELD boardcode AS CHAR
-        FIELD addoncodes AS CHAR EXTENT 6
-        FIELD scores AS CHAR
-        FIELD length AS DEC
-        FIELD width AS DEC
-        FIELD instructions AS CHAR
-        FIELD stackheight AS CHAR
-        FIELD overrunpct AS CHAR
-        FIELD underrunpct AS CHAR  .
+    FIELD customerpo AS INTEGER
+    FIELD lineNo AS INTEGER
+    FIELD shipto AS CHARACTER
+    FIELD shiptoaddress AS CHARACTER
+    FIELD customerponbr AS CHARACTER
+    FIELD customerpolineseqnbr AS CHARACTER
+    FIELD internalprodno AS CHARACTER
+    FIELD custitemname AS CHARACTER
+    FIELD custitemdscr1 AS CHARACTER
+    FIELD custitemdscr2 AS CHARACTER
+    FIELD quantityordered AS DECIMAL
+    FIELD uom AS CHARACTER
+    FIELD duedate AS CHARACTER
+/*    FIELD duetime AS CHARACTER*/
+    FIELD currentdatetime AS CHARACTER
+    FIELD boardcode AS CHARACTER
+    FIELD addoncodes AS CHARACTER EXTENT 6
+    FIELD scores AS CHARACTER
+    FIELD length AS DECIMAL
+    FIELD width AS DECIMAL
+    FIELD instructions AS CHARACTER
+/*    FIELD stackheight AS CHARACTER*/
+    FIELD overrunpcnt AS CHARACTER
+    FIELD underrunpcnt AS CHARACTER  .
 
-DEF TEMP-TABLE scores
-  FIELD customerpo AS INT
-  FIELD lineNo AS INT
-  FIELD scorecode AS CHAR
-  FIELD scoresequence AS INT
-  FIELD score AS CHAR
-  .
+DEFINE TEMP-TABLE scores
+    FIELD customerpo AS INTEGER
+    FIELD lineNo AS INTEGER
+    FIELD scorecode AS CHARACTER
+    FIELD scoresequence AS INTEGER
+    FIELD score AS CHARACTER
+    .
   
-DEF TEMP-TABLE addoncodes
-  FIELD customerpo AS INT
-  FIELD lineNo AS INT
-  FIELD addoncode AS CHAR
-
-  .
+DEFINE TEMP-TABLE addoncodes
+    FIELD customerpo AS INTEGER
+    FIELD lineNo AS INTEGER
+    FIELD addoncode AS CHARACTER
+    .
+    
+DEFINE TEMP-TABLE ttPartnerValue
+    FIELD partnervalue AS CHAR.
+    .
+    
 DEFINE DATASET pkgcustomxmlorders 
     FOR sheetorder, detailline, AddonCodes, scores
     DATA-RELATION custOrd FOR sheetorder, detailline     
@@ -122,363 +127,410 @@ DEFINE VARIABLE lOmitInitialValues AS LOGICAL NO-UNDO.
 
 {sys/inc/gp.i}
 
-FIND FIRST po-ctrl NO-LOCK WHERE po-ctrl.company EQ cocode.
+FIND FIRST po-ctrl NO-LOCK WHERE 
+    po-ctrl.company EQ cocode
+    NO-ERROR.
+IF NOT AVAIL po-ctrl THEN DO:
+    MESSAGE 
+        "PO control record not found for company " + cocode + "."
+        VIEW-AS ALERT-BOX ERROR.
+    RETURN.
+END.
+        
 
-FIND FIRST company NO-LOCK WHERE company.company EQ cocode.
+FIND FIRST company NO-LOCK WHERE 
+    company.company EQ cocode
+    NO-ERROR.
+IF NOT AVAIL po-ctrl THEN DO:
+    MESSAGE 
+        "Company record not found for company " + cocode + "."
+        VIEW-AS ALERT-BOX ERROR.
+    RETURN.
+END.
 
 IF gp-log AND gp-dir NE "" THEN
-print-po-blok:
-FOR EACH report NO-LOCK WHERE report.term-id EQ v-term-id,
-    FIRST po-ord
-    WHERE RECID(po-ord) EQ report.rec-id
-      AND CAN-FIND(FIRST po-ordl
-                   WHERE po-ordl.company   EQ po-ord.company
-                     AND po-ordl.po-no     EQ po-ord.po-no
-                     AND po-ordl.item-type EQ YES
-                     AND (v-printde-po OR NOT po-ordl.deleted)),
+    print-po-blok:
+    FOR EACH report NO-LOCK WHERE 
+        report.term-id EQ v-term-id,
+        FIRST po-ord 
+        WHERE 
+            RECID(po-ord) EQ report.rec-id AND 
+            CAN-FIND(FIRST po-ordl WHERE 
+                po-ordl.company   EQ po-ord.company AND 
+                po-ordl.po-no     EQ po-ord.po-no AND 
+                po-ordl.item-type EQ YES AND 
+                (v-printde-po OR NOT po-ordl.deleted)),
+        FIRST vend NO-LOCK WHERE 
+            vend.company    EQ po-ord.company AND 
+            vend.vend-no    EQ po-ord.vend-no AND 
+            (vend.po-export EQ "GP" OR (poexport-cha  EQ "GP" AND vend.an-edi-vend))
+        BREAK BY po-ord.po-no:
 
-    FIRST vend NO-LOCK
-    WHERE vend.company    EQ po-ord.company
-      AND vend.vend-no    EQ po-ord.vend-no
-      AND (vend.po-export EQ "GP" OR
-           (poexport-cha  EQ "GP" AND vend.an-edi-vend))
-
-    BREAK BY po-ord.po-no:
-
-  IF FIRST(po-ord.po-no) THEN DO:
-    IF OPSYS EQ "UNIX" AND SUBSTR(gp-dir,1,1) NE v-slash THEN
-      gp-dir = v-slash + gp-dir.
-
-    IF SUBSTR(gp-dir,LENGTH(gp-dir),1) EQ v-slash THEN
-      SUBSTR(gp-dir,LENGTH(gp-dir),1) = "".
-
-    /* Output to a temporary file */
-    ASSIGN
-     iNextLine = 0
-     v-outfile[1] = TRIM(gp-dir) + v-slash + "dataxfer" +
-                    v-slash + "in" + v-slash
-     v-outfile[2] = v-outfile[1] + STRING(TIME,"99999999")
-     v-outfile[3] = "po_" + TRIM(REPLACE(v-format, " ","")) + "GP" +
-                    SUBSTR(STRING(YEAR(TODAY),"9999"),3,2) +
-                    STRING(MONTH(TODAY),"99") +
-                    STRING(DAY(TODAY),"99") +
-                    SUBSTR(STRING(TIME,"HH:MM:SS"),1,2) +
-                    SUBSTR(STRING(TIME,"HH:MM:SS"),4,2) +
-                    SUBSTR(STRING(TIME,"HH:MM:SS"),7,2) + ".xml"
-     v-outfile[4] = v-outfile[1] + v-outfile[3]
-     v-outfile[4] = REPLACE (v-outfile[4], "'", '').
-      FILE-INFO:FILE-NAME = v-outfile[1].
-      IF FILE-INFO:FILE-TYPE EQ ?  THEN        
-          OS-COMMAND SILENT  "mkdir " + value(v-outfile[1]). 
-    /* OUTPUT TO VALUE(v-outfile[4]). */
-  END.
-
-  IF po-ord.stat EQ "N" THEN po-ord.stat = "O".
-   CREATE sheetorder .
-
-  ASSIGN
-      sheetorder.customerpo = po-ord.po-no
-      /* sheetorder.canonicalfile = " " */
-      sheetorder.purchasedby = po-ord.buyer
-      sheetorder.plantid = vend.name
-      sheetorder.billto = company.name.
-
-  v-instr = "".
-  FOR EACH notes WHERE notes.rec_key EQ po-ord.rec_key NO-LOCK:
-    IF notes.note_text NE "" THEN 
-      v-instr = TRIM(v-instr)                         +
-                (IF v-instr EQ "" THEN "" ELSE ".**") +
-                TRIM(notes.note_text).
-  END.
-
-  sheetorder.ordernotes =  v-instr  .
-
-  ASSIGN
-   v-sname    = company.name
-   v-saddr[1] = company.addr[1]
-   v-saddr[2] = company.addr[2]
-   v-scity    = company.city
-   v-sstate   = company.state
-   v-szip     = company.zip.
- 
-  IF po-ord.type EQ "D" THEN
-    ASSIGN
-     v-sname    = po-ord.ship-name
-     v-saddr[1] = po-ord.ship-addr[1]
-     v-saddr[2] = po-ord.ship-addr[2]
-     v-scity    = po-ord.ship-city
-     v-sstate   = po-ord.ship-state
-     v-szip     = po-ord.ship-zip.
-  
-  FOR EACH po-ordl
-      WHERE po-ordl.company   EQ po-ord.company
-        AND po-ordl.po-no     EQ po-ord.po-no
-        AND po-ordl.item-type EQ YES
-        AND (v-printde-po OR NOT po-ordl.deleted) ,
-      
-      FIRST item NO-LOCK
-      WHERE item.company  EQ cocode
-        AND item.i-no     EQ po-ordl.i-no
-        AND item.mat-type EQ "B"
-      
-      BY po-ordl.line WITH FRAME po-line:
-      
-    ASSIGN
-     xg-flag = NO
-     v-adder = "".
-    
-    FIND FIRST job NO-LOCK
-        WHERE job.company EQ cocode
-          AND job.job-no  EQ FILL(" ",6 - LENGTH(TRIM(po-ordl.job-no))) +
-                                  TRIM(po-ordl.job-no)
-          AND job.job-no2 EQ po-ordl.job-no2
-        NO-ERROR.
-        
-    IF AVAIL job THEN DO:
-      FIND FIRST est NO-LOCK
-          WHERE est.company EQ job.company
-            AND est.est-no  EQ job.est-no
-          NO-ERROR.
-      
-      FOR EACH job-mat NO-LOCK
-          WHERE job-mat.company  EQ cocode
-            AND job-mat.job      EQ job.job
-            AND job-mat.job-no   EQ job.job-no
-            AND job-mat.job-no2  EQ job.job-no2
-            AND job-mat.i-no     EQ po-ordl.i-no
-            AND job-mat.frm      EQ po-ordl.s-num
-          USE-INDEX job
-          BREAK BY job-mat.blank-no DESC:
-        IF LAST(job-mat.blank-no)            OR
-           job-mat.blank-no EQ po-ordl.b-num THEN LEAVE.
-      END.
-
-      IF AVAIL job-mat THEN DO:
-        FIND FIRST ef NO-LOCK
-            WHERE ef.e-num   EQ job.e-num
-              AND ef.form-no EQ job-mat.frm
+        FIND FIRST sys-ctrl-shipto NO-LOCK WHERE
+            sys-ctrl-shipto.company EQ po-ord.company AND 
+            sys-ctrl-shipto.name EQ "GP" AND 
+            sys-ctrl-shipto.cust-vend EQ FALSE AND 
+            sys-ctrl-shipto.cust-vend-no EQ po-ord.vend-no
             NO-ERROR.
-   
-        ASSIGN
-         xg-flag = AVAIL ef AND (ef.xgrain EQ "S" OR ef.xgrain EQ "B")
-         i       = 0.
-         
-        FOR EACH xjob-mat NO-LOCK
-            WHERE xjob-mat.company  EQ cocode
-              AND xjob-mat.job      EQ job-mat.job
-              AND xjob-mat.job-no   EQ job-mat.job-no
-              AND xjob-mat.job-no2  EQ job-mat.job-no2
-              AND xjob-mat.frm      EQ job-mat.frm
-              AND xjob-mat.blank-no EQ job-mat.blank-no
-              AND xjob-mat.i-no     NE job-mat.i-no,
-              
-            FIRST xitem NO-LOCK
-            WHERE xitem.company  EQ cocode 
-              AND xitem.i-no     EQ xjob-mat.i-no
-              AND xitem.mat-type EQ "A":
-              
-          ASSIGN
-           i          = i + 1
-           v-adder[i] = xitem.i-no.
-             
-          IF i GE 6 THEN LEAVE.
+        IF gp-int EQ 1 
+        AND AVAIL sys-ctrl-shipto THEN DO:
+            CREATE ttPartnerValue.
+            ASSIGN
+                ttPartnerValue.partnervalue = ENTRY(1,sys-ctrl-shipto.char-fld,"|")
+                lUseNew = TRUE.
         END.
-      END.
-    END.
+ 
+         IF FIRST(po-ord.po-no) THEN DO:
+            IF OPSYS EQ "UNIX" AND SUBSTR(gp-dir,1,1) NE v-slash THEN
+                gp-dir = v-slash + gp-dir.
 
-    iNextLine = iNextLine + 1.
-    CREATE detailline .
-    ASSIGN
-        detailline.lineNo     = iNextLine
-        detailline.customerpo = po-ord.po-no
-        detailline.shipto = v-sname
-        detailline.shiptoaddress = v-saddr[1] + " " + v-saddr[2] + " " + v-scity + " " +
-                                    v-sstate + " " + v-szip
-        detailline.customerponbr = STRING(po-ord.po-no)
-        detailline.customerpolineseqnbr = string(po-ordl.line)
-        detailline.internalprodno = po-ordl.job-no + "-" + STRING(po-ordl.job-no2,"99") + "-" + STRING(po-ordl.s-num,"99")
-        detailline.custitemname = po-ordl.i-name
-        detailline.custitemdscr1 = po-ordl.dscr[1]
-        detailline.custitemdscr2 = po-ordl.dscr[2] .
+            IF SUBSTR(gp-dir,LENGTH(gp-dir),1) EQ v-slash THEN
+                SUBSTR(gp-dir,LENGTH(gp-dir),1) = "".
 
-    v-ord-qty = po-ordl.ord-qty.
-    
-    IF po-ordl.pr-qty-uom NE "EA" THEN
-      RUN sys/ref/convquom.p(po-ordl.pr-qty-uom, "EA",
-                             item.basis-w, po-ordl.s-len,
-                             po-ordl.s-wid, item.s-dep,
-                             v-ord-qty, OUTPUT v-ord-qty).
-                           
-    IF v-ord-qty - TRUNC(v-ord-qty,0) GT 0 THEN
-      v-ord-qty = TRUNC(v-ord-qty,0) + 1.
-     ASSIGN
-         detailline.quantityordered = v-ord-qty
-         detailline.uom = "EA"
-         detailline.duedate = STRING(po-ordl.due-date,"99/99/99")
-         detailline.duetime = STRING(61200,"HH:MM")
-         detailline.currentdatetime = STRING(TODAY,"999999") + " " + STRING(TIME,"HH:MM")
-         detailline.boardcode = po-ordl.i-no .
+            /* Output to a temporary file */
+            ASSIGN
+                iNextLine = 0
+                v-outfile[1] = TRIM(gp-dir) + v-slash + "dataxfer" + v-slash + "in" + v-slash
+                v-outfile[2] = v-outfile[1] + STRING(TIME,"99999999")
+                v-outfile[3] = "po_" + TRIM(REPLACE(v-format, " ","")) + "GP" +
+                                SUBSTR(STRING(YEAR(TODAY),"9999"),3,2) +
+                                STRING(MONTH(TODAY),"99") +
+                                STRING(DAY(TODAY),"99") +
+                                SUBSTR(STRING(TIME,"HH:MM:SS"),1,2) +
+                                SUBSTR(STRING(TIME,"HH:MM:SS"),4,2) +
+                                SUBSTR(STRING(TIME,"HH:MM:SS"),7,2) + ".xml"
+                v-outfile[4] = v-outfile[1] + v-outfile[3]
+                v-outfile[4] = REPLACE (v-outfile[4], "'", '').
+            
+            FILE-INFO:FILE-NAME = v-outfile[1].
+            IF FILE-INFO:FILE-TYPE EQ ?  THEN        
+                OS-COMMAND SILENT  "mkdir " + VALUE(v-outfile[1]). 
+        /* OUTPUT TO VALUE(v-outfile[4]). */
+        END.
 
-    DO i = 1 TO 6:
+        IF po-ord.stat EQ "N" THEN 
+            po-ord.stat = "O".
+        CREATE sheetorder .
 
-      IF v-adder[i] NE "" THEN DO:
-
-        CREATE addoncodes.
-
-        ASSIGN 
-          addoncodes.customerPO = detailline.customerPo
-          addoncodes.lineNo     = detailline.lineNo
-          addoncodes.addoncode  = v-adder[i].
-          /* ASSIGN detailline.addoncodes[i] = v-adder[i] . */
-
-      END. /* if v-adder[i] ne "" ... */
-          
-    END. /* do i = 1 to 6 */
-
-    RUN po/po-ordls.p (RECID(po-ordl)).
-    
-    {po/po-ordls.i}
-
-    EMPTY TEMP-TABLE tt-score.   
-    
-    IF AVAIL b-ref1 THEN
-    DO i = 1 TO 12:
-      IF b-ref1.val[i] NE 0 THEN DO:
-        CREATE tt-score.
         ASSIGN
-         tt-seq  = i
-        tt-type = SUBSTR(b-ref1.dscr,i,1)
-        tt-scor = TRUNC(b-ref1.val[i],0) +
-                   ((b-ref1.val[i] - TRUNC(b-ref1.val[i],0)) * 6.25).
-      END.
-    END.
+            sheetorder.customerpo = po-ord.po-no
+            /* sheetorder.canonicalfile = " " */
+            sheetorder.purchasedby = IF lUseNew THEN CAPS(ENTRY(1, sys-ctrl-shipto.char-fld,"|")) ELSE po-ord.buyer
+            sheetorder.plantid = IF lUseNew THEN ENTRY(2, sys-ctrl-shipto.char-fld,"|") ELSE vend.name
+            sheetorder.billto = IF lUseNew THEN ENTRY(1, sys-ctrl-shipto.char-fld,"|") + " " + 
+                                ENTRY(2, sys-ctrl-shipto.char-fld,"|") ELSE company.name.
 
-    IF AVAIL b-ref2 THEN
-    DO i = 1 TO 8:
-      IF b-ref2.val[i] NE 0 THEN DO:
-        CREATE tt-score.
+        v-instr = "".
+        FOR EACH notes WHERE notes.rec_key EQ po-ord.rec_key NO-LOCK:
+            IF notes.note_text NE "" THEN 
+                v-instr = TRIM(v-instr)                         +
+                    (IF v-instr EQ "" THEN "" ELSE ".**") +
+                    TRIM(notes.note_text).
+        END.
+
+/*        sheetorder.ordernotes =  v-instr  .*/
+
         ASSIGN
-        tt-seq  = 12 + i
-        tt-type = SUBSTR(b-ref2.dscr,i,1)
-        tt-scor = TRUNC(b-ref2.val[i],0) +
-                   ((b-ref2.val[i] - TRUNC(b-ref2.val[i],0)) * 6.25).
-      END.
-    END.
-
-      i = 0.
-      FOR EACH tt-score BREAK BY tt-seq:
-          IF NOT FIRST(tt-seq) OR
-              NOT LAST(tt-seq)  THEN 
-          DO:
-
-        i = i + 1.
+            v-sname    = company.name
+            v-saddr[1] = company.addr[1]
+            v-saddr[2] = company.addr[2]
+            v-scity    = company.city
+            v-sstate   = company.state
+            v-szip     = company.zip.
+ 
+        IF po-ord.type EQ "D" THEN
+            ASSIGN
+                v-sname    = po-ord.ship-name
+                v-saddr[1] = po-ord.ship-addr[1]
+                v-saddr[2] = po-ord.ship-addr[2]
+                v-scity    = po-ord.ship-city
+                v-sstate   = po-ord.ship-state
+                v-szip     = po-ord.ship-zip.
+  
+        FOR EACH po-ordl
+            WHERE po-ordl.company   EQ po-ord.company
+            AND po-ordl.po-no     EQ po-ord.po-no
+            AND po-ordl.item-type EQ YES
+            AND (v-printde-po OR NOT po-ordl.deleted) ,
       
-          CREATE scores.
-          ASSIGN 
-          scores.customerpo    = detailline.customerPo
-          scores.lineNo        = iNextLine
-          scores.scoresequence = i - 1
-          scores.score         = STRING(tt-scor)
-          scores.scorecode     = tt-type.            
-          
-
-      END.
-    END.
-
-    ASSIGN detailline.length = po-ordl.s-len
-           detailline.width = po-ordl.s-wid .
-     
-    v-instr = "".
-    FOR EACH notes WHERE notes.rec_key EQ po-ordl.rec_key NO-LOCK:
-      IF notes.note_text NE "" THEN 
-        v-instr = TRIM(v-instr)                         +
-                  (IF v-instr EQ "" THEN "" ELSE ".**") +
-                  TRIM(notes.note_text).
-    END.
-
-    ASSIGN detailline.instructions = v-instr
-           detailline.overrunpct = STRING(po-ord.over-pct )
-           detailline.underrunpct = STRING(po-ord.under-pct) .
-
-  END. /* FOR EACH po-ordl record */
-
-  /*PUT UNFORMATTED
-      "</sheetorder>".*/
-
-  po-ord.printed = YES.
-  IF LAST(po-ord.po-no) AND CAN-FIND( FIRST sheetorder)
-     /* SEARCH(v-outfile[4]) NE ? */ THEN DO:
-
-      DEFINE VARIABLE returnValue AS LOGICAL NO-UNDO.
-      DEFINE VARIABLE hPDS AS HANDLE.
-      hPDS = DATASET pkgcustomxmlorders:HANDLE.
+            FIRST item NO-LOCK
+            WHERE item.company  EQ cocode
+            AND item.i-no     EQ po-ordl.i-no
+            AND item.mat-type EQ "B"
       
-      ASSIGN
-          cTargetType = "FILE"
-          cFile = session:TEMP-DIR + "\" + USERID("Nosweat") + STRING(TIME)
-          lFormatted = YES
-          cEncoding = ?
-          cSchemaLocation = ?
-          lWriteSchema = NO
-          lMinSchema = TRUE
-          lWriteBeforeImage = FALSE
-          lOmitInitialValues = FALSE.
+            BY po-ordl.line WITH FRAME po-line:
       
-      /*** Before the method call, your application does work with its data. ***/
-      
-      returnValue = hPDS:WRITE-XML (cTargetType, cFile, lFormatted, cEncoding, 
-                                    cSchemaLocation, lWriteSchema, lMinSchema, 
-                                    lWriteBeforeImage, lOmitInitialValues).
-/*   For Testing....                                                    */
-/*       IF returnValue = FALSE THEN DO:                                          */
-/*           MESSAGE "WRITE-XML on ProDataSet failed!" VIEW-AS ALERT-BOX.         */
-/*           RETURN.                                                              */
-/*       END.                                                                     */
-/*       ELSE                                                                     */
-/*           MESSAGE "Successful WRITE-XML on : " v-outfile[4] VIEW-AS ALERT-BOX. */
-      DELETE OBJECT hPDS.
-
-      /* Take out lines from XML that were needed to join the temp-tables */
-      /* In the DataSet                                                   */      
-      OUTPUT STREAM sOut TO VALUE(v-outfile[4]).
-      INPUT FROM VALUE(cFile).
-
-      REPEAT:
-      
-        cInLn = "".
-        IMPORT DELIMITER "`" cInln.
-
-        /* Needed internally, not in file */
-        IF INDEX(cInLn, "<customerpo>") GT 0  THEN
-          NEXT.
+            ASSIGN
+                xg-flag = NO
+                v-adder = "".
+    
+            FIND FIRST job NO-LOCK
+                WHERE job.company EQ cocode
+                AND job.job-no  EQ FILL(" ",6 - LENGTH(TRIM(po-ordl.job-no))) +
+                TRIM(po-ordl.job-no)
+                AND job.job-no2 EQ po-ordl.job-no2
+                NO-ERROR.
         
-        /* Needed internally, not in file */
-        IF cInLN BEGINS "<lineNo>" THEN
-          NEXT.
+            IF AVAILABLE job THEN 
+            DO:
+                FIND FIRST est NO-LOCK
+                    WHERE est.company EQ job.company
+                    AND est.est-no  EQ job.est-no
+                    NO-ERROR.
+      
+                FOR EACH job-mat NO-LOCK
+                    WHERE job-mat.company  EQ cocode
+                    AND job-mat.job      EQ job.job
+                    AND job-mat.job-no   EQ job.job-no
+                    AND job-mat.job-no2  EQ job.job-no2
+                    AND job-mat.i-no     EQ po-ordl.i-no
+                    AND job-mat.frm      EQ po-ordl.s-num
+                    USE-INDEX job
+                    BREAK BY job-mat.blank-no DESCENDING:
+                    IF LAST(job-mat.blank-no)            OR
+                        job-mat.blank-no EQ po-ordl.b-num THEN LEAVE.
+                END.
 
-        /* Remove empty sections */
-        IF cInLn EQ "<addoncodes/>" THEN
-          NEXT.
+                IF AVAILABLE job-mat THEN 
+                DO:
+                    FIND FIRST ef NO-LOCK
+                        WHERE ef.e-num   EQ job.e-num
+                        AND ef.form-no EQ job-mat.frm
+                        NO-ERROR.
+   
+                    ASSIGN
+                        xg-flag = AVAILABLE ef AND (ef.xgrain EQ "S" OR ef.xgrain EQ "B")
+                        i       = 0.
+         
+                    FOR EACH xjob-mat NO-LOCK
+                        WHERE xjob-mat.company  EQ cocode
+                        AND xjob-mat.job      EQ job-mat.job
+                        AND xjob-mat.job-no   EQ job-mat.job-no
+                        AND xjob-mat.job-no2  EQ job-mat.job-no2
+                        AND xjob-mat.frm      EQ job-mat.frm
+                        AND xjob-mat.blank-no EQ job-mat.blank-no
+                        AND xjob-mat.i-no     NE job-mat.i-no,
+              
+                        FIRST xitem NO-LOCK
+                        WHERE xitem.company  EQ cocode 
+                        AND xitem.i-no     EQ xjob-mat.i-no
+                        AND xitem.mat-type EQ "A":
+              
+                        ASSIGN
+                            i          = i + 1
+                            v-adder[i] = xitem.i-no.
+             
+                        IF i GE 6 THEN LEAVE.
+                    END.
+                END.
+            END.
+
+            iNextLine = iNextLine + 1.
+            CREATE detailline .
+            ASSIGN
+                detailline.lineNo     = iNextLine
+                detailline.customerpo = po-ord.po-no
+                detailline.shipto = v-sname
+                detailline.shiptoaddress = v-saddr[1] + " " + v-saddr[2] + " " + v-scity + " " +
+                                    v-sstate + " " + v-szip
+                detailline.customerponbr = STRING(po-ord.po-no)
+                detailline.customerpolineseqnbr = STRING(po-ordl.line)
+                detailline.internalprodno = po-ordl.job-no + "-" + STRING(po-ordl.job-no2,"99") + "-" + STRING(po-ordl.s-num,"99")
+                detailline.custitemname = po-ordl.i-name
+                detailline.custitemdscr1 = po-ordl.dscr[1]
+                detailline.custitemdscr2 = po-ordl.dscr[2] .
+
+            v-ord-qty = po-ordl.ord-qty.
+    
+            IF po-ordl.pr-qty-uom NE "EA" THEN
+                RUN sys/ref/convquom.p(po-ordl.pr-qty-uom, "EA",
+                    item.basis-w, po-ordl.s-len,
+                    po-ordl.s-wid, item.s-dep,
+                    v-ord-qty, OUTPUT v-ord-qty).
+                           
+            IF v-ord-qty - TRUNC(v-ord-qty,0) GT 0 THEN
+                v-ord-qty = TRUNC(v-ord-qty,0) + 1.
+            ASSIGN
+                detailline.quantityordered = v-ord-qty
+                detailline.uom = "EA"
+                detailline.duedate = STRING(po-ordl.due-date,"99/99/99")
+/*                detailline.duetime = STRING(61200,"HH:MM")*/
+                detailline.currentdatetime = STRING(TODAY,"999999") + " " + STRING(TIME,"HH:MM")
+                detailline.boardcode = po-ordl.i-no .
+
+            DO i = 1 TO 6:
+
+                IF v-adder[i] NE "" THEN 
+                DO:
+
+                    CREATE addoncodes.
+
+                    ASSIGN 
+                        addoncodes.customerPO = detailline.customerPo
+                        addoncodes.lineNo     = detailline.lineNo
+                        addoncodes.addoncode  = v-adder[i].
+                /* ASSIGN detailline.addoncodes[i] = v-adder[i] . */
+
+                END. /* if v-adder[i] ne "" ... */
           
-        IF cInLn EQ "<scores/>" THEN 
-          NEXT.
+            END. /* do i = 1 to 6 */
 
-        PUT STREAM sOut UNFORMATTED cInln SKIP.
+            RUN po/po-ordls.p (RECID(po-ordl)).
+    
+            {po/po-ordls.i}
 
-      END. /* Repeat */
+            EMPTY TEMP-TABLE tt-score.   
+    
+            IF AVAILABLE b-ref1 THEN
+            DO i = 1 TO 12:
+                IF b-ref1.val[i] NE 0 THEN 
+                DO:
+                    CREATE tt-score.
+                    ASSIGN
+                        tt-seq  = i
+                        tt-type = SUBSTR(b-ref1.dscr,i,1)
+                        tt-scor = TRUNC(b-ref1.val[i],0) +
+                   ((b-ref1.val[i] - TRUNC(b-ref1.val[i],0)) * 6.25).
+                END.
+            END.
 
-      INPUT CLOSE.
-      OUTPUT STREAM sOut CLOSE.
+            IF AVAILABLE b-ref2 THEN
+            DO i = 1 TO 8:
+                IF b-ref2.val[i] NE 0 THEN 
+                DO:
+                    CREATE tt-score.
+                    ASSIGN
+                        tt-seq  = 12 + i
+                        tt-type = SUBSTR(b-ref2.dscr,i,1)
+                        tt-scor = TRUNC(b-ref2.val[i],0) +
+                   ((b-ref2.val[i] - TRUNC(b-ref2.val[i],0)) * 6.25).
+                END.
+            END.
+
+            i = 0.
+            FOR EACH tt-score BREAK BY tt-seq:
+                IF NOT FIRST(tt-seq) OR
+                    NOT LAST(tt-seq)  THEN 
+                DO:
+
+                    i = i + 1.
+      
+                    CREATE scores.
+                    ASSIGN 
+                        scores.customerpo    = detailline.customerPo
+                        scores.lineNo        = iNextLine
+                        scores.scoresequence = i /* - 1 */
+                        scores.score         = STRING(tt-scor)
+                        scores.scorecode     = tt-type.            
+          
+
+                END.
+            END.
+
+            ASSIGN 
+                detailline.length = po-ordl.s-len
+                detailline.width = po-ordl.s-wid .
+     
+            v-instr = "".
+            FOR EACH notes WHERE notes.rec_key EQ po-ordl.rec_key NO-LOCK:
+                IF notes.note_text NE "" THEN 
+                    v-instr = TRIM(v-instr)                         +
+                        (IF v-instr EQ "" THEN "" ELSE ".**") +
+                        TRIM(notes.note_text).
+            END.
+
+            ASSIGN 
+                detailline.instructions = v-instr
+                detailline.overrunpcnt = STRING(po-ord.over-pct )
+                detailline.underrunpcnt = STRING(po-ord.under-pct) .
+
+        END. /* FOR EACH po-ordl record */
+
+        /*PUT UNFORMATTED
+            "</sheetorder>".*/
+
+        po-ord.printed = YES.
+        IF LAST(po-ord.po-no) AND CAN-FIND( FIRST sheetorder)
+        /* SEARCH(v-outfile[4]) NE ? */ THEN 
+        DO:
+
+            DEFINE VARIABLE returnValue AS LOGICAL NO-UNDO.
+            DEFINE VARIABLE hPDS AS HANDLE.
+            hPDS = DATASET pkgcustomxmlorders:HANDLE.
+      
+            ASSIGN
+                cTargetType = "FILE"
+                cFile = SESSION:TEMP-DIR + "\" + USERID("Nosweat") + STRING(TIME)
+                lFormatted = YES
+                cEncoding = ?
+                cSchemaLocation = ?
+                lWriteSchema = NO
+                lMinSchema = TRUE
+                lWriteBeforeImage = FALSE
+                lOmitInitialValues = FALSE.
+      
+            /*** Before the method call, your application does work with its data. ***/
+      
+            returnValue = hPDS:WRITE-XML (cTargetType, cFile, lFormatted, cEncoding, 
+                cSchemaLocation, lWriteSchema, lMinSchema, 
+                lWriteBeforeImage, lOmitInitialValues).
+            /*   For Testing....                                                    */
+            /*       IF returnValue = FALSE THEN DO:                                          */
+            /*           MESSAGE "WRITE-XML on ProDataSet failed!" VIEW-AS ALERT-BOX.         */
+            /*           RETURN.                                                              */
+            /*       END.                                                                     */
+            /*       ELSE                                                                     */
+            /*           MESSAGE "Successful WRITE-XML on : " v-outfile[4] VIEW-AS ALERT-BOX. */
+            DELETE OBJECT hPDS.
+
+            /* Take out lines from XML that were needed to join the temp-tables */
+            /* In the DataSet                                                   */      
+            OUTPUT STREAM sOut TO VALUE(v-outfile[4]).
+            INPUT FROM VALUE(cFile).
+
+            REPEAT:
+      
+                cInLn = "".
+                IMPORT DELIMITER "`" cInln.
+
+                /* Needed internally, not in file */
+                IF INDEX(cInLn, "<customerpo>") GT 0  THEN
+                    NEXT.
+        
+                /* Needed internally, not in file */
+                IF cInLN BEGINS "<lineNo>" THEN
+                    NEXT.
+
+                /* Remove empty sections */
+                IF cInLn EQ "<addoncodes/>" THEN
+                    NEXT.
+          
+                IF cInLn EQ "<scores/>" THEN 
+                    NEXT.
+
+                IF gp-int EQ 1 
+                AND cInLn EQ "<sheetorder>" THEN
+                    PUT STREAM sOut UNFORMATTED 
+                         "<partnervalue>" +
+                         CAPS(ENTRY(1, sys-ctrl-shipto.char-fld,"|")) + 
+                         "</partnervalue>" + CHR(10).
+                         
+                PUT STREAM sOut UNFORMATTED cInln SKIP.
+
+            END. /* Repeat */
+
+            INPUT CLOSE.
+            OUTPUT STREAM sOut CLOSE.
       
       
-      OS-DELETE VALUE(cFile).
-      RUN po/ftppo.p (v-outfile[4], "GP").
+            OS-DELETE VALUE(cFile).
+            RUN po/ftppo.p (v-outfile[4], "GP").
 
-      MESSAGE "Georgia Pacific file:" TRIM(v-outfile[3]) "has been created"
-          VIEW-AS ALERT-BOX.
+            MESSAGE "Georgia Pacific file:" TRIM(v-outfile[3]) "has been created"
+                VIEW-AS ALERT-BOX.
           
           
-  END. /* Last of po # */
-END. /* FOR EACH po-ord record */
+        END. /* Last of po # */
+    END. /* FOR EACH po-ord record */
 
 /* end ----------------------------------- Copr. 2006  Advanced Software Inc. */

--- a/Source/po/po-hrexp.p
+++ b/Source/po/po-hrexp.p
@@ -4,744 +4,637 @@
 /*                                                                            */
 /* -------------------------------------------------------------------------- */
 
-DEF INPUT PARAMETER v-format AS CHAR NO-UNDO.
+DEFINE INPUT PARAMETER v-format AS CHARACTER NO-UNDO.
 
 {sys/inc/var.i shared}
 {sys/form/s-top.f}
 
-DEF BUFFER xjob-mat FOR job-mat.
-DEF BUFFER xitem FOR item.
-DEF BUFFER b-ref1  FOR reftable.
-DEF BUFFER b-ref2  FOR reftable.
-def var cWinScpXmlLog as char.
-def stream sReadLog.
-def stream sLogFileTest.
+DEFINE BUFFER xjob-mat FOR job-mat.
+DEFINE BUFFER xitem FOR item.
+DEFINE BUFFER b-ref1  FOR reftable.
+DEFINE BUFFER b-ref2  FOR reftable.
+DEFINE BUFFER bpo-ord FOR po-ord.
+DEFINE VARIABLE cWinScpXmlLog AS CHARACTER.
+DEFINE STREAM sReadLog.
+DEFINE STREAM sLogFileTest.
 {po/po-print.i}
 {po/getPoAdders.i}
 
-DEF VAR v-sname LIKE shipto.ship-name.
-DEF VAR v-saddr LIKE shipto.ship-addr.
-DEF VAR v-scity LIKE shipto.ship-city.
-DEF VAR v-sstate LIKE shipto.ship-state.
-DEF VAR v-szip LIKE shipto.ship-zip.
-DEF VAR v-adder LIKE item.i-no EXTENT 7 NO-UNDO.
-DEF VAR xg-flag AS LOG INIT NO NO-UNDO.
-DEF VAR v-instr AS CHAR NO-UNDO.
-DEF VAR v-ord-qty LIKE po-ordl.ord-qty EXTENT 4 NO-UNDO.
-DEF VAR v-ord-cst LIKE po-ordl.cost NO-UNDO.
-DEF VAR v-setup LIKE e-item-vend.setup NO-UNDO.
-DEF VAR v-outfile AS CHAR EXTENT 4 NO-UNDO.
-DEF VAR v-mach AS CHAR EXTENT 4 NO-UNDO.
-DEF VAR v-line AS CHAR NO-UNDO.
-DEF VAR li-style AS INT NO-UNDO.
+DEFINE VARIABLE v-sname LIKE shipto.ship-name.
+DEFINE VARIABLE v-saddr LIKE shipto.ship-addr.
+DEFINE VARIABLE v-scity LIKE shipto.ship-city.
+DEFINE VARIABLE v-sstate LIKE shipto.ship-state.
+DEFINE VARIABLE v-szip LIKE shipto.ship-zip.
+DEFINE VARIABLE v-adder LIKE item.i-no EXTENT 7 NO-UNDO.
+DEFINE VARIABLE xg-flag AS LOG INIT NO NO-UNDO.
+DEFINE VARIABLE v-instr AS CHARACTER NO-UNDO.
+DEFINE VARIABLE v-ord-qty LIKE po-ordl.ord-qty EXTENT 4 NO-UNDO.
+DEFINE VARIABLE v-ord-cst LIKE po-ordl.cost NO-UNDO.
+DEFINE VARIABLE v-setup LIKE e-item-vend.setup NO-UNDO.
+DEFINE VARIABLE v-outfile AS CHARACTER EXTENT 4 NO-UNDO.
+DEFINE VARIABLE v-mach AS CHARACTER EXTENT 4 NO-UNDO.
+DEFINE VARIABLE v-line AS CHARACTER NO-UNDO.
 DEFINE VARIABLE iNumericAdder AS INTEGER NO-UNDO.
 DEFINE VARIABLE cAssignedCustId AS CHARACTER NO-UNDO.
 DEFINE VARIABLE iAdderCount AS INTEGER NO-UNDO.
 DEFINE VARIABLE iTempAdder AS INTEGER NO-UNDO.
+DEFINE VARIABLE vCarrierDesc AS CHAR NO-UNDO.
+DEFINE VARIABLE vFobCode AS CHAR NO-UNDO.
+DEFINE VARIABLE vCustCityState AS CHAR NO-UNDO.
+DEFINE VARIABLE vShipCityState AS CHAR NO-UNDO.
+DEFINE VARIABLE vDueDate AS CHAR NO-UNDO.
+DEFINE VARIABLE vWidthInt AS CHAR NO-UNDO.
+DEFINE VARIABLE vWidthNum AS CHAR NO-UNDO.
+DEFINE VARIABLE vWidthDen AS CHAR NO-UNDO.
+DEFINE VARIABLE vWidth AS CHAR NO-UNDO.
+DEFINE VARIABLE vLengthInt AS CHAR NO-UNDO.
+DEFINE VARIABLE vLengthNum AS CHAR NO-UNDO.
+DEFINE VARIABLE vLengthDen AS CHAR NO-UNDO.
+DEFINE VARIABLE vLength AS CHAR NO-UNDO.
+DEFINE VARIABLE vStyleCode AS INTEGER NO-UNDO.
+DEFINE VARIABLE vStyleDesc AS CHAR NO-UNDO.
+DEFINE VARIABLE vScore AS CHAR NO-UNDO.
+DEFINE VARIABLE vOutWidth AS CHAR NO-UNDO.
+DEFINE VARIABLE vBlankWidth AS CHAR NO-UNDO.
+DEFINE VARIABLE vScore2 AS CHAR NO-UNDO.
+DEFINE VARIABLE v-jobno AS CHAR NO-UNDO.
+DEFINE VARIABLE v-form AS CHAR NO-UNDO.
 
-DEF TEMP-TABLE tt-eiv NO-UNDO
-    FIELD run-qty AS DEC DECIMALS 3 EXTENT 20
-    FIELD setups AS DEC DECIMALS 2 EXTENT 20.
+DEFINE TEMP-TABLE tt-eiv NO-UNDO
+    FIELD run-qty AS DECIMAL DECIMALS 3 EXTENT 20
+    FIELD setups AS DECIMAL DECIMALS 2 EXTENT 20.
 
 {sys/inc/hrms.i}
 
-FIND FIRST po-ctrl WHERE po-ctrl.company EQ cocode NO-LOCK.
+FIND FIRST po-ctrl NO-LOCK WHERE 
+    po-ctrl.company EQ cocode.
+FIND FIRST company NO-LOCK WHERE 
+    company.company EQ cocode.
+FIND FIRST cust NO-LOCK WHERE 
+    cust.company EQ cocode AND 
+    cust.active  EQ "X"
+    NO-ERROR.
 
-FIND FIRST company WHERE company.company EQ cocode NO-LOCK.
+ASSIGN 
+    cAssignedCustId = "00105".  /* Default value */ 
 
-FIND FIRST cust
-    WHERE cust.company EQ cocode
-      AND cust.active  EQ "X"
-    NO-LOCK NO-ERROR.
-cAssignedCustId = "00105". 
-
-IF AVAIL cust AND hrms-log AND hrms-dir NE "" THEN
+IF AVAILABLE cust 
+AND hrms-log AND hrms-dir NE "" THEN
 print-po-blok:
-FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
-
-    FIRST po-ord
-    WHERE RECID(po-ord) EQ report.rec-id
-      AND CAN-FIND(FIRST po-ordl
-                   WHERE po-ordl.company   EQ po-ord.company
-                     AND po-ordl.po-no     EQ po-ord.po-no
-                     AND po-ordl.item-type EQ YES
-                     AND (v-printde-po OR NOT po-ordl.deleted)),
-
-    FIRST vend
-    WHERE vend.company EQ po-ord.company
-      AND vend.vend-no EQ po-ord.vend-no
-      AND (vend.po-export EQ "HRMS" OR
-           (poexport-cha  EQ "HRMS" AND vend.an-edi-vend))
-    NO-LOCK
-    BY po-ord.po-no.
+FOR EACH report NO-LOCK WHERE 
+    report.term-id EQ v-term-id,
+    FIRST po-ord NO-LOCK WHERE 
+        RECID(po-ord) EQ report.rec-id AND 
+        CAN-FIND(FIRST po-ordl WHERE 
+            po-ordl.company   EQ po-ord.company AND 
+            po-ordl.po-no     EQ po-ord.po-no AND 
+            po-ordl.item-type EQ YES AND 
+            (v-printde-po OR NOT po-ordl.deleted)),
+    FIRST vend NO-LOCK WHERE 
+        vend.company EQ po-ord.company AND 
+        vend.vend-no EQ po-ord.vend-no AND 
+        (vend.po-export EQ "HRMS" OR (poexport-cha  EQ "HRMS" AND vend.an-edi-vend))
+    BY po-ord.po-no:
   
-  /* Cross-reference vendor to vendors customer number */  
-  FIND FIRST sys-ctrl-shipto NO-LOCK  
-       WHERE sys-ctrl-shipto.company EQ po-ord.company
-         AND sys-ctrl-shipto.cust-vend = FALSE 
-         AND sys-ctrl-shipto.cust-vend-no EQ po-ord.vend-no
-       NO-ERROR.
-  IF AVAILABLE sys-ctrl-shipto THEN 
-      cAssignedCustId = sys-ctrl-shipto.char-fld.
+    /* Cross-reference vendor to vendors customer number */  
+    FIND FIRST sys-ctrl-shipto NO-LOCK WHERE 
+        sys-ctrl-shipto.company EQ po-ord.company AND 
+        sys-ctrl-shipto.cust-vend = FALSE AND 
+        sys-ctrl-shipto.cust-vend-no EQ po-ord.vend-no
+        NO-ERROR.
+    IF AVAILABLE sys-ctrl-shipto THEN ASSIGN  
+        cAssignedCustId = sys-ctrl-shipto.char-fld.
 
-  IF OPSYS EQ "UNIX" AND substr(hrms-dir,1,1) NE v-slash THEN
-    hrms-dir = v-slash + hrms-dir.
-
-  IF substr(hrms-dir,LENGTH(hrms-dir),1) EQ v-slash THEN
-    substr(hrms-dir,LENGTH(hrms-dir),1) = "".
-    
-  ASSIGN
-   v-outfile[1] = TRIM(hrms-dir) + v-slash + "dataxfer" +
-                  v-slash + "in" + v-slash
-   v-outfile[2] = v-outfile[1] + string(TIME,"99999999")
-   v-outfile[3] = "po_" + trim(REPLACE(v-format, " ","")) + vend.vend-no +
-                  substr(STRING(YEAR(TODAY),"9999"),3,2) +
-                  string(MONTH(TODAY),"99") +
-                  string(DAY(TODAY),"99") +
-                  substr(STRING(TIME,"HH:MM:SS"),1,2) +
-                  substr(STRING(TIME,"HH:MM:SS"),4,2) +
-                  substr(STRING(TIME,"HH:MM:SS"),7,2) + ".dat"
-   v-outfile[4] = v-outfile[1] + v-outfile[3].
+    ASSIGN 
+        hrms-dir        = TRIM(hrms-dir,"/")
+        hrms-dir        = TRIM(hrms-dir,"\")
+        v-outfile[1]    = TRIM(hrms-dir) + "\dataxfer\in\"
+        v-outfile[2]    = v-outfile[1] + STRING(TIME,"99999999")
+        v-outfile[3]    = "po_" + TRIM(REPLACE(v-format, " ","")) + vend.vend-no +
+                            SUBSTRING(STRING(YEAR(TODAY),"9999"),3,2) +
+                            STRING(MONTH(TODAY),"99") +
+                            STRING(DAY(TODAY),"99") +
+                            SUBSTRING(STRING(TIME,"HH:MM:SS"),1,2) +
+                            SUBSTRING(STRING(TIME,"HH:MM:SS"),4,2) +
+                            SUBSTRING(STRING(TIME,"HH:MM:SS"),7,2) + ".dat"
+        v-outfile[4]    = v-outfile[1] + v-outfile[3].
    
     FILE-INFO:FILE-NAME = v-outfile[1].
     IF FILE-INFO:FILE-TYPE EQ ?  THEN        
-        OS-COMMAND SILENT  "mkdir " + value(v-outfile[1]).
-  OUTPUT to value(v-outfile[2]).
+        OS-COMMAND SILENT  "mkdir " + VALUE(v-outfile[1]).
+    OUTPUT TO VALUE(v-outfile[2]).
 
-  IF po-ord.stat EQ "N" THEN po-ord.stat = "O".
+    IF po-ord.stat EQ "N" THEN DO:
+        FIND bpo-ord EXCLUSIVE WHERE 
+            ROWID(bpo-ord) = ROWID(po-ord).
+        ASSIGN 
+            bpo-ord.stat = "O".
+    END.
 
-  ASSIGN
-   v-sname    = cust.name
-   v-saddr[1] = cust.addr[1]
-   v-saddr[2] = cust.addr[2]
-   v-scity    = cust.city
-   v-sstate   = cust.state
-   v-szip     = cust.zip.
- 
-  IF po-ord.type EQ "D" THEN
     ASSIGN
-     v-sname    = po-ord.ship-name
-     v-saddr[1] = po-ord.ship-addr[1]
-     v-saddr[2] = po-ord.ship-addr[2]
-     v-scity    = po-ord.ship-city
-     v-sstate   = po-ord.ship-state
-     v-szip     = po-ord.ship-zip.
+        v-sname    = cust.name
+        v-saddr[1] = cust.addr[1]
+        v-saddr[2] = cust.addr[2]
+        v-scity    = cust.city
+        v-sstate   = cust.state
+        v-szip     = cust.zip.
+ 
+    IF po-ord.type EQ "D" THEN ASSIGN
+        v-sname    = po-ord.ship-name
+        v-saddr[1] = po-ord.ship-addr[1]
+        v-saddr[2] = po-ord.ship-addr[2]
+        v-scity    = po-ord.ship-city
+        v-sstate   = po-ord.ship-state
+        v-szip     = po-ord.ship-zip.
 
-  FIND FIRST carrier
-      WHERE carrier.company EQ po-ord.company
+    FIND FIRST carrier
+        WHERE carrier.company EQ po-ord.company
         AND carrier.carrier EQ po-ord.carrier
-      NO-LOCK NO-ERROR.
-
-  /* Order Download Specification */
-
-  /* H1 */
-
-  /* CUSTOMER # */
-  PUT cAssignedCustId                                     FORMAT "x(5)".
-
-  /* 01 */
-  PUT "01"                                        FORMAT "x(2)".
-
-  /* 000000 */
-  PUT "000000"                                    FORMAT "x(6)".
-
-  /* CUSTOMER PHONE # */
-  PUT cust.area-code                              FORMAT "999"
-      "-"                                         FORMAT "x"
-      cust.phone                                  FORMAT "999-9999".
-
-  /* CUSTOMER BILLING ZIP */
-  PUT cust.zip                                    FORMAT "x(12)".
-
-  /* SHIP VIA */
-  PUT STRING(IF AVAIL carrier THEN carrier.dscr ELSE po-ord.carrier)
-                                                  FORMAT "x(15)".
-
-  /* FREIGHT */
-  PUT IF po-ord.fob-code EQ "DEST" THEN "DESTINATION" ELSE "ORIGIN"
-                                                  FORMAT "x(15)".
-
-  /* P.O. DATE */
-  PUT po-ord.po-date                              FORMAT "99999999".
-
-  /* 000 */
-  PUT FILL(" ",3)                                 FORMAT "x(3)".
-
-  /* CUST # */
-  PUT cAssignedCustId /*cust.cust-no*/                    FORMAT "x(5)".
-
-  /* 45 blank spaces */
-  PUT FILL(" ",45)                                FORMAT "x(45)"      SKIP.
-
-  /* H2 */
-    
-  /* CUST BILLING NAME */
-  PUT cust.name                                   FORMAT "x(30)".
-    
-  /* CUST BILLING ADDRESS */
-  PUT cust.addr[1]                                FORMAT "x(30)".
-    
-  /* CUST BILLING ADDRESS */
-  PUT cust.addr[2]                                FORMAT "x(30)".
-    
-  /* CUST BILLING CITY, ST */
-  PUT TRIM(cust.city) + " " + trim(cust.state)    FORMAT "x(30)".
-
-  /* 8 blank spaces */
-  PUT FILL(" ",8)                                 FORMAT "x(8)"       SKIP.
-
-  /* H3 */
-    
-  /* CUST SHIP TO NAME */
-  PUT v-sname                                     FORMAT "x(30)".
-    
-  /* CUST SHIP TO ADDRESS */
-  PUT v-saddr[1]                                  FORMAT "x(30)".
-    
-  /* CUST SHIP TO ADDRESS */
-  PUT v-saddr[2]                                  FORMAT "x(30)".
-    
-  /* CUST SHIP TO CITY, ST */
-  PUT TRIM(v-scity) + " " + trim(v-sstate)        FORMAT "x(30)".
-
-  /* 8 blank spaces */
-  PUT FILL(" ",8)                                 FORMAT "x(8)"       SKIP.
-
-  FOR EACH po-ordl
-      WHERE po-ordl.company   EQ po-ord.company
-        AND po-ordl.po-no     EQ po-ord.po-no
-        AND po-ordl.item-type EQ YES
-        AND (v-printde-po OR NOT po-ordl.deleted),
-      
-      FIRST item
-      WHERE item.company  EQ cocode
-        AND item.i-no     EQ po-ordl.i-no
-        AND item.mat-type EQ "B"
-      NO-LOCK
-      
-      BY po-ordl.line:
-      
-    ASSIGN
-     xg-flag = NO
-     v-adder = "".
-    
-    FIND FIRST job
-        WHERE job.company EQ cocode
-          AND job.job-no  EQ fill(" ",6 - length(TRIM(po-ordl.job-no))) +
-                                  trim(po-ordl.job-no)
-          AND job.job-no2 EQ po-ordl.job-no2
         NO-LOCK NO-ERROR.
-        
-    IF AVAIL job THEN DO:
-      FIND FIRST est
-          WHERE est.company EQ job.company
-            AND est.est-no  EQ job.est-no
-          NO-LOCK NO-ERROR.
-      
-      FOR EACH job-mat
-          WHERE job-mat.company  EQ cocode
-            AND job-mat.job      EQ job.job
-            AND job-mat.job-no   EQ job.job-no
-            AND job-mat.job-no2  EQ job.job-no2
-            AND job-mat.i-no     EQ po-ordl.i-no
-            AND job-mat.frm      EQ po-ordl.s-num
-          USE-INDEX job NO-LOCK
-          BREAK BY job-mat.blank-no DESC:
-        IF LAST(job-mat.blank-no)            OR
-           job-mat.blank-no EQ po-ordl.b-num THEN LEAVE.
-      END.
-
-      IF AVAIL job-mat THEN DO:
-        FIND FIRST ef
-            WHERE ef.e-num   EQ job.e-num
-              AND ef.form-no EQ job-mat.frm
-            NO-LOCK NO-ERROR.
-   
-        ASSIGN
-         xg-flag = AVAIL ef AND (ef.xgrain EQ "S" OR ef.xgrain EQ "B")
-         i       = 0.
+    ASSIGN 
+        vCarrierDesc    = IF AVAIL carrier THEN carrier.dscr ELSE po-ord.carrier 
+        vFobCode        = IF po-ord.fob-code EQ "DEST" THEN "DESTINATION" ELSE "ORIGIN"
+        vCustCityState  = TRIM(cust.city) + " " + TRIM(cust.state)
+        vShipCityState  = TRIM(v-scity) + " " + TRIM(v-sstate).
          
-        FOR EACH xjob-mat
-            WHERE xjob-mat.company  EQ cocode
-              AND xjob-mat.job      EQ job-mat.job
-              AND xjob-mat.job-no   EQ job-mat.job-no
-              AND xjob-mat.job-no2  EQ job-mat.job-no2
-              AND xjob-mat.frm      EQ job-mat.frm
-              AND xjob-mat.blank-no EQ job-mat.blank-no
-              AND xjob-mat.i-no     NE job-mat.i-no
-            NO-LOCK,
-              
-            FIRST xitem
-            WHERE xitem.company  EQ cocode 
-              AND xitem.i-no     EQ xjob-mat.i-no
-              AND xitem.mat-type EQ "A"
-            NO-LOCK,
-            
-            FIRST reftable
-            WHERE reftable.reftable EQ "util/b-hrms-x.w"
-              AND reftable.company  EQ xitem.company
-              AND reftable.code2    EQ xitem.i-no
-            NO-LOCK:          
-              ASSIGN
-                  i          = i + 1
-              .
-              
-              iTempAdder = INT(reftable.code) NO-ERROR.
-              IF NOT ERROR-STATUS:ERROR THEN 
-                 v-adder[i] = STRING(INT(reftable.code),"9999").
-                 
-              IF i GE 6 THEN LEAVE.
-        END.
-      END.
-    END.
-
     /* Order Download Specification */
-    
-    /* D1 */
+    /* H1 */
+    PUT 
+        cAssignedCustId     FORMAT "x(5)"       /* CUSTOMER # */
+        "01"                FORMAT "x(2)"       /* 01 */
+        "000000"            FORMAT "x(6)"       /* 000000 */
+        cust.area-code      FORMAT "999"        /* CUSTOMER PHONE # (pt 1) */
+        "-"                 FORMAT "x"          /* CUSTOMER PHONE # (pt 2) */
+        cust.phone          FORMAT "999-9999"   /* CUSTOMER PHONE # (pt 3) */
+        cust.zip            FORMAT "x(12)"      /* CUSTOMER BILLING ZIP */
+        vCarrierDesc        FORMAT "x(15)"      /* SHIP VIA */
+        vFobCode            FORMAT "x(15)"      /* FREIGHT */
+        po-ord.po-date      FORMAT "99999999"   /* P.O. DATE */
+        FILL(" ",3)         FORMAT "x(3)"       /* 000 */
+        cAssignedCustId     FORMAT "x(5)"       /* CUST # */
+        FILL(" ",45)        FORMAT "x(45)"      /* 45 blank spaces */
+        SKIP.
 
-    /* CUSTOMER # */
-    PUT cAssignedCustId /*cust.cust-no*/                    FORMAT "x(5)".
+    /* H2 */
+    PUT 
+        cust.name           FORMAT "x(30)"      /* CUST BILLING NAME */
+        cust.addr[1]        FORMAT "x(30)"      /* CUST BILLING ADDRESS */
+        cust.addr[2]        FORMAT "x(30)"      /* CUST BILLING ADDRESS */
+        vCustCityState      FORMAT "x(30)"      /* CUST BILLING CITY, ST */
+        FILL(" ",8)         FORMAT "x(8)"       /* 8 blank spaces */   
+        SKIP. 
 
-    /* 01 */
-    PUT "01"                                        FORMAT "x(2)".
-    
-    /* PURCHASE ORDER # */
-    PUT po-ord.po-no                                FORMAT "999999".
+    /* H3 */
+    PUT 
+        v-sname             FORMAT "x(30)"      /* CUST SHIP TO NAME */
+        v-saddr[1]          FORMAT "x(30)"      /* CUST SHIP TO ADDRESS */
+        v-saddr[2]          FORMAT "x(30)"      /* CUST SHIP TO ADDRESS */
+        vShipCityState      FORMAT "x(30)"      /* CUST SHIP TO CITY, ST */
+        FILL(" ",8)         FORMAT "x(8)"       /* 8 blank spaces */    
+        SKIP.
 
-    /* A */
-    PUT "A"                                         FORMAT "x(1)".
-    
-    /* PURCHASE ORDER # */
-    PUT po-ordl.line                                FORMAT "99".
-    
-    /* PURCHASE ORDER # */
-    PUT po-ord.po-no                                FORMAT "999999".
+    FOR EACH po-ordl NO-LOCK WHERE  
+        po-ordl.company   EQ po-ord.company AND 
+        po-ordl.po-no     EQ po-ord.po-no AND 
+        po-ordl.item-type EQ YES AND 
+        (v-printde-po OR NOT po-ordl.deleted),
+        FIRST ITEM NO-LOCK WHERE 
+            item.company  EQ cocode AND 
+            item.i-no     EQ po-ordl.i-no AND 
+            item.mat-type EQ "B"
+        BY po-ordl.line:
+  
+        ASSIGN
+            xg-flag = NO
+            v-adder = "".
 
-    /* A */
-    PUT "A"                                         FORMAT "x(1)".
-    
-    /* PURCHASE ORDER # */
-    PUT po-ordl.line                                FORMAT "99".
-    
-    /* MESSAGE CODE #1 */
-    PUT FILL(" ",2)                                 FORMAT "xx".
-    
-    /* MESSAGE CODE #2 */
-    PUT FILL(" ",2)                                 FORMAT "xx".
-    
-    /* MESSAGE CODE #3 */
-    PUT FILL(" ",2)                                 FORMAT "xx".
-    
-    /* 7 blank spaces */
-    PUT FILL(" ",7)                                 FORMAT "x(7)".
-    
-    /* BY */
-    PUT "BY"                                        FORMAT "x(5)".
-    
-    /* DUE DATE */
-    PUT substr(STRING(YEAR(po-ordl.due-date),"9999"),3,2)  +
-        string(MONTH(po-ordl.due-date),"99") +
-        string(DAY(po-ordl.due-date),"99")          FORMAT "x(6)".
-    
-    /* OVERRUN PERCENTAGE */
-    PUT po-ord.over-pct                             FORMAT "99".
-    
-    /* UNDERRUN PERCENTAGE */
-    PUT po-ord.under-pct                            FORMAT "99".
+        FIND FIRST job NO-LOCK WHERE 
+            job.company EQ cocode AND 
+            job.job-no  EQ FILL(" ",6 - LENGTH(TRIM(po-ordl.job-no))) + TRIM(po-ordl.job-no) AND 
+            job.job-no2 EQ po-ordl.job-no2
+            NO-ERROR.
         
-    /* INTEGER OF WIDTH */
-    PUT trunc(po-ordl.s-wid,0)                      FORMAT "999999".
-
-    /* NUMERATOR OF WIDTH */
-    PUT (po-ordl.s-wid - trunc(po-ordl.s-wid,0)) * 16
-                                                    FORMAT "99".
-    /* DENOMINATOR OF WIDTH */
-    PUT 16                                          FORMAT "99".
-        
-    /* WIDTH */
-    PUT trunc(po-ordl.s-wid,0)                      FORMAT "999"
-        ":"                                         FORMAT "x"
-        (po-ordl.s-wid - trunc(po-ordl.s-wid,0)) * 16
-                                                    FORMAT "99".
-        
-    /* INTEGER OF LENGTH */
-    PUT trunc(po-ordl.s-len,0)                      FORMAT "999999".
-
-    /* NUMERATOR OF LENGTH */
-    PUT (po-ordl.s-len - trunc(po-ordl.s-len,0)) * 16
-                                                    FORMAT "99".
-    /* DENOMINATOR OF LENGTH */
-    PUT 16                                          FORMAT "99".
-        
-    /* LENGTH */
-    PUT trunc(po-ordl.s-len,0)                      FORMAT "999"
-        ":"                                         FORMAT "x"
-        (po-ordl.s-len - trunc(po-ordl.s-len,0)) * 16
-                                                    FORMAT "99".
-    
-    /* STYLE NUMBER */
-    RUN po/po-ordls.p (RECID(po-ordl)).
-    
-    {po/po-ordls.i}
- 
-    li-style = IF AVAIL b-ref1 OR AVAIL b-ref2 THEN 1 ELSE 2.
-
-    PUT li-style                                    FORMAT "9999".
-    
-    /* STYLE DESCRIPTION */
-    PUT (IF li-style EQ 1 THEN "SCORED" ELSE "TRIMMED") + " SHEET"
-                                                    FORMAT "x(14)".
-    
-    /* WEIGHT OF BOARD */
-    PUT item.basis-w                                FORMAT "9999".
-        
-    /* QUANTITY SHEETS */
-    v-ord-qty[1] = po-ordl.ord-qty.
-    
-    IF po-ordl.pr-qty-uom NE "EA" THEN
-      RUN sys/ref/convquom.p(po-ordl.pr-qty-uom, "EA",
-                             item.basis-w, po-ordl.s-len,
-                             po-ordl.s-wid, item.s-dep,
-                             v-ord-qty[1], OUTPUT v-ord-qty[1]).
-                           
-    IF v-ord-qty[1] - trunc(v-ord-qty[1],0) GT 0 THEN
-      v-ord-qty[1] = trunc(v-ord-qty[1],0) + 1.
-
-    v-ord-qty[2] = v-ord-qty[1].
-
-    IF v-ord-qty[1] GT 99999999 THEN v-ord-qty[1] = 99999999.
-    
-    PUT v-ord-qty[1]                                FORMAT "99999999".
-
-    /* 13 blank spaces */
-    PUT FILL(" ",13)                                FORMAT "x(13)"      SKIP.
-    
-    /* D2 */
-    
-    /* FLUTE */
-    PUT item.flute                                  FORMAT "x(3)".
-    
-    /* PRICE PER MSF */
-    v-ord-cst = po-ordl.cost.
-    
-    IF po-ordl.pr-uom NE "MSF" THEN
-      RUN sys/ref/convcuom.p(po-ordl.pr-uom, "MSF",
-                             item.basis-w, po-ordl.s-len,
-                             po-ordl.s-wid, item.s-dep,
-                             v-ord-cst, OUTPUT v-ord-cst).
-
-    IF v-ord-cst GT 9999.99 THEN v-ord-cst = 9999.99.
-                           
-    PUT v-ord-cst                                   FORMAT "9999.99".
-        
-    /* SETUP CHARGE */
-    v-setup = 0.
-
-    RELEASE e-item.
-    RELEASE e-item-vend.
-
-    FIND FIRST e-item OF item NO-LOCK NO-ERROR.
-
-    IF AVAIL e-item THEN
-    FIND FIRST e-item-vend OF e-item
-        WHERE e-item-vend.vend-no   EQ po-ord.vend-no
-          AND e-item-vend.item-type EQ YES
-        NO-LOCK NO-ERROR.
-    
-    IF AVAIL e-item-vend THEN DO:
-      v-ord-qty[3] = po-ordl.ord-qty.
-
-      IF po-ordl.pr-qty-uom NE e-item.std-uom THEN
-        RUN sys/ref/convquom.p(po-ordl.pr-qty-uom, e-item.std-uom,
-                               item.basis-w, po-ordl.s-len,
-                               po-ordl.s-wid, item.s-dep,
-                               v-ord-qty[3], OUTPUT v-ord-qty[3]).
-
-      EMPTY TEMP-TABLE tt-eiv.
-      CREATE tt-eiv.
-      DO i = 1 TO 10:
-         ASSIGN
-            tt-eiv.run-qty[i] = e-item-vend.run-qty[i]
-            tt-eiv.setups[i] = e-item-vend.setups[i].
-      END.
-
+        IF AVAILABLE job THEN DO:
+            FIND FIRST est NO-LOCK WHERE 
+                est.company EQ job.company AND 
+                est.est-no  EQ job.est-no
+                NO-ERROR.
       
-      IF AVAIL e-item-vend THEN
-      DO:
-         
-      
-         DO i = 1 TO 10:
-            ASSIGN
-               tt-eiv.run-qty[i + 10] = e-item-vend.runQtyXtra[i]
-               tt-eiv.setups[i + 10] = e-item-vend.setupsXtra[i].
-         END.
-      END.
-                           
-      DO i = 1 TO 20:
-        IF v-ord-qty[3] LE tt-eiv.run-qty[i] THEN DO:
-           v-setup = tt-eiv.setups[i].
-           LEAVE.
+            FOR EACH job-mat NO-LOCK WHERE 
+                job-mat.company  EQ cocode AND 
+                job-mat.job      EQ job.job AND 
+                job-mat.job-no   EQ job.job-no AND 
+                job-mat.job-no2  EQ job.job-no2 AND 
+                job-mat.i-no     EQ po-ordl.i-no AND 
+                job-mat.frm      EQ po-ordl.s-num
+                USE-INDEX job
+                BREAK BY job-mat.blank-no DESCENDING:
+                IF LAST(job-mat.blank-no)
+                OR job-mat.blank-no EQ po-ordl.b-num THEN LEAVE.
+            END.
+
+            IF AVAILABLE job-mat THEN DO:
+                FIND FIRST ef NO-LOCK WHERE 
+                    ef.e-num   EQ job.e-num AND 
+                    ef.form-no EQ job-mat.frm
+                    NO-ERROR.
+   
+                ASSIGN
+                    xg-flag = AVAILABLE ef AND (ef.xgrain EQ "S" OR ef.xgrain EQ "B")
+                    i       = 1.
+     
+                FIND FIRST reftable
+                    WHERE reftable.reftable EQ "util/b-hrms-x.w"
+                    AND reftable.company  EQ po-ordl.company
+                    AND reftable.code2    EQ po-ordl.i-no
+                    NO-LOCK NO-ERROR.
+                IF AVAIL reftable THEN ASSIGN 
+                    v-adder[i] = STRING(INT(reftable.code),"9999").
+                ELSE ASSIGN 
+                    v-adder[1] = STRING("0000","x(4)").
+
+                FOR EACH xjob-mat NO-LOCK WHERE 
+                    xjob-mat.company  EQ cocode AND 
+                    xjob-mat.job      EQ job-mat.job AND 
+                    xjob-mat.job-no   EQ job-mat.job-no AND 
+                    xjob-mat.job-no2  EQ job-mat.job-no2 AND 
+                    xjob-mat.frm      EQ job-mat.frm AND 
+                    xjob-mat.blank-no EQ job-mat.blank-no AND 
+                    xjob-mat.i-no     NE job-mat.i-no,
+                    FIRST xitem NO-LOCK WHERE 
+                        xitem.company  EQ cocode AND 
+                        xitem.i-no     EQ xjob-mat.i-no AND 
+                        xitem.mat-type EQ "A",
+                    FIRST reftable NO-LOCK WHERE 
+                        reftable.reftable EQ "util/b-hrms-x.w" AND 
+                        reftable.company  EQ xitem.company AND 
+                        reftable.code2    EQ xitem.i-no:          
+                    ASSIGN
+                        i = i + 1
+                        v-form = STRING(job-mat.frm,"99").
+          
+                    iTempAdder = INT(reftable.code) NO-ERROR.
+                    IF NOT ERROR-STATUS:ERROR THEN 
+                        v-adder[i] = STRING(INT(reftable.code),"9999").
+                    ELSE ASSIGN 
+                        v-adder[i] = STRING("0000","9999").
+             
+                    IF i GE 6 THEN LEAVE.
+                END.
+            END.
         END.
-      END.
-    END.
-
-    IF v-setup GT 999.99 THEN v-setup = 999.99.
-    
-    PUT v-setup                                     FORMAT "999.99".
-
-    /* "001.00" */
-    PUT 1                                           FORMAT "999.99".
-
-    /* "00000000.0000" */
-    PUT 0                                           FORMAT "99999999.9999".
         
-    /* ORDERED SF */
-    v-ord-qty[3] = po-ordl.ord-qty.
-    
-    IF po-ordl.pr-qty-uom NE "SF" THEN
-      RUN sys/ref/convquom.p(po-ordl.pr-qty-uom, "SF",
-                             item.basis-w, po-ordl.s-len,
-                             po-ordl.s-wid, item.s-dep,
-                             v-ord-qty[3], OUTPUT v-ord-qty[3]).
-                           
-    IF v-ord-qty[3] - trunc(v-ord-qty[3],0) GT 0 THEN
-      v-ord-qty[3] = trunc(v-ord-qty[3],0) + 1.
+        ASSIGN 
+            vDueDate    = SUBSTRING(STRING(YEAR(po-ordl.due-date),"9999"),3,2)  +
+                          STRING(MONTH(po-ordl.due-date),"99") +
+                          STRING(DAY(po-ordl.due-date),"99")
+            vWidthInt   = STRING(TRUNC(po-ordl.s-wid,0),"999999")
+            vWidthNum   = STRING((po-ordl.s-wid - trunc(po-ordl.s-wid,0)) * 16,"99")
+            vWidthDen   = "16"
+            vWidth      = STRING(TRUNC(po-ordl.s-wid,0),"999") + ":" + STRING((po-ordl.s-wid - trunc(po-ordl.s-wid,0)) * 16,"99")  
+            vLengthInt  = STRING(TRUNC(po-ordl.s-len,0),"999999")
+            vLengthNum  = STRING((po-ordl.s-len - trunc(po-ordl.s-len,0)) * 16,"99")
+            vLengthDen  = "16"
+            vLength     = STRING(TRUNC(po-ordl.s-len,0),"999") + ":" + STRING((po-ordl.s-len - trunc(po-ordl.s-len,0)) * 16,"99")
+            .   
 
-    v-ord-qty[4] = v-ord-qty[3].
-
-    IF v-ord-qty[3] GT 9999999 THEN v-ord-qty[3] = 9999999.
-    
-    PUT v-ord-qty[3]                                FORMAT "9999999".
-
-    /* 46 blank spaces */
-    PUT FILL(" ",46)                                FORMAT "x(46)".
-
-    /* "X" */
-    PUT "X"                                         FORMAT "x".
-
-    /* "X" */
-    PUT "X"                                         FORMAT "x".
-
-    /* DESCRIPTION TEXT */
-    PUT po-ordl.i-name                              FORMAT "x(30)".
-
-    /* 8 blank spaces */
-    PUT FILL(" ",8)                                 FORMAT "x(8)"       SKIP.
-    
-    /* D3 */
-
-    /* 128 blank spaces */
-    PUT po-ordl.i-name                               FORMAT "x(128)"     SKIP.
-    
-    /* D4 */
-    
-    /* SCORE */
-    DO i = 1 TO 9:
-      IF AVAIL b-ref1 AND b-ref1.val[i] NE 0 THEN 
-        PUT trunc(b-ref1.val[i],0)                  FORMAT ">>>"
-            ":"                                     FORMAT "x"
-            (b-ref1.val[i] - trunc(b-ref1.val[i],0)) * 100
-                                                    FORMAT "99"
-            substr(b-ref1.dscr,i,1)                 FORMAT "x".
+        /* STYLE CODE */
+        RUN po/po-ordls.p (RECID(po-ordl)).
+        {po/po-ordls.i}
+        ASSIGN  
+            vStyleCode = IF AVAILABLE b-ref1 OR AVAILABLE b-ref2 THEN 1 ELSE 2
+            vStyleDesc = (IF vStyleCode EQ 1 THEN "SCORED" ELSE "TRIMMED") + " SHEET".
             
-      ELSE PUT "       "                            FORMAT "x(7)".
-    END.
+        /* QUANTITY SHEETS */
+        ASSIGN 
+            v-ord-qty[1] = po-ordl.ord-qty.
+        IF po-ordl.pr-qty-uom NE "EA" THEN
+            RUN sys/ref/convquom.p(po-ordl.pr-qty-uom, "EA",
+                item.basis-w, po-ordl.s-len,
+                po-ordl.s-wid, item.s-dep,
+                v-ord-qty[1], OUTPUT v-ord-qty[1]).
+        IF v-ord-qty[1] - trunc(v-ord-qty[1],0) GT 0 THEN
+            v-ord-qty[1] = trunc(v-ord-qty[1],0) + 1.
+        ASSIGN 
+            v-ord-qty[2] = v-ord-qty[1].
+        IF v-ord-qty[1] GT 99999999 THEN v-ord-qty[1] = 99999999.
 
-    /* NUMBER UP */
-    PUT 1                                           FORMAT "999.99".
+        /* PRICE PER MSF */
+        ASSIGN 
+            v-ord-cst = po-ordl.cost.
+        IF po-ordl.pr-uom NE "MSF" THEN
+            RUN sys/ref/convcuom.p(po-ordl.pr-uom, "MSF",
+                item.basis-w, po-ordl.s-len,
+                po-ordl.s-wid, item.s-dep,
+                v-ord-cst, OUTPUT v-ord-cst).
+        IF v-ord-cst GT 9999.99 THEN v-ord-cst = 9999.99.
+        /* END PRICE PER MSF */
+                       
+        /* SETUP CHARGE */
+        RELEASE e-item.
+        RELEASE e-item-vend.
+        ASSIGN 
+            v-setup = 0.
+        FIND FIRST e-item OF item NO-LOCK NO-ERROR.
+        IF AVAILABLE e-item THEN FIND FIRST e-item-vend OF e-item WHERE 
+                e-item-vend.vend-no   EQ po-ord.vend-no AND 
+                e-item-vend.item-type EQ YES
+                NO-LOCK NO-ERROR.
+        IF AVAILABLE e-item-vend THEN 
+        DO:
+            v-ord-qty[3] = po-ordl.ord-qty.
+            IF po-ordl.pr-qty-uom NE e-item.std-uom THEN
+                RUN sys/ref/convquom.p(po-ordl.pr-qty-uom, e-item.std-uom,
+                    item.basis-w, po-ordl.s-len,
+                    po-ordl.s-wid, item.s-dep,
+                    v-ord-qty[3], OUTPUT v-ord-qty[3]).
+            EMPTY TEMP-TABLE tt-eiv.
+            CREATE tt-eiv.
+            DO i = 1 TO 10:
+                ASSIGN
+                    tt-eiv.run-qty[i] = e-item-vend.run-qty[i]
+                    tt-eiv.setups[i] = e-item-vend.setups[i].
+            END.
+            IF AVAILABLE e-item-vend THEN 
+            DO:
+                DO i = 1 TO 10:
+                    ASSIGN
+                        tt-eiv.run-qty[i + 10] = e-item-vend.runQtyXtra[i]
+                        tt-eiv.setups[i + 10] = e-item-vend.setupsXtra[i].
+                END.
+            END.
+            DO i = 1 TO 20:
+                IF v-ord-qty[3] LE tt-eiv.run-qty[i] THEN 
+                DO:
+                    v-setup = tt-eiv.setups[i].
+                    LEAVE.
+                END.
+            END.
+        END.
+        IF v-setup GT 999.99 THEN v-setup = 999.99.
+        /* END SETUP CHARGE */
 
-    /* TRIM */
-    PUT FILL(" ",2)                                 FORMAT "xx".
+        /* ORDERED SF */
+        ASSIGN 
+            v-ord-qty[3] = po-ordl.ord-qty.
+        IF po-ordl.pr-qty-uom NE "SF" THEN
+            RUN sys/ref/convquom.p(po-ordl.pr-qty-uom, "SF",
+                item.basis-w, po-ordl.s-len,
+                po-ordl.s-wid, item.s-dep,
+                v-ord-qty[3], OUTPUT v-ord-qty[3]).
+        IF v-ord-qty[3] - trunc(v-ord-qty[3],0) GT 0 THEN
+            v-ord-qty[3] = trunc(v-ord-qty[3],0) + 1.
+        ASSIGN 
+            v-ord-qty[4] = v-ord-qty[3].
+        IF v-ord-qty[3] GT 9999999 THEN v-ord-qty[3] = 9999999.
+        /* END ORDERED SF */
 
-    /* 1 OUT WIDTH, NO TRIM */
-    PUT trunc(po-ordl.s-wid,0)                      FORMAT "999"
-        ":"                                         FORMAT "x"
-        (po-ordl.s-wid - trunc(po-ordl.s-wid,0)) * 16
-                                                    FORMAT "99".
+        /* SCORE */
+        DO i = 1 TO 9:
+            IF AVAILABLE b-ref1 AND b-ref1.val[i] NE 0 THEN ASSIGN 
+                    vScore = vScore + STRING(TRUNC(b-ref1.val[i],0), ">>>") +
+                                  ":" +
+                                  STRING((b-ref1.val[i] - trunc(b-ref1.val[i],0)) * 100,"99") +
+                                  substr(b-ref1.dscr,i,1).
+        
+            ELSE ASSIGN 
+                    vScore = vScore + "       ".
+        END.
+        /* END SCORE */
+        
+        /* Additional Scores */
+        DO i = 10 TO 12:
+            IF AVAILABLE b-ref1 AND b-ref1.val[i] NE 0 THEN ASSIGN 
+                    vScore2 = vScore2 + STRING(TRUNC(b-ref1.val[i],0), ">>>") +
+                                  ":" +
+                                  STRING((b-ref1.val[i] - trunc(b-ref1.val[i],0)) * 100,"99") +
+                                  substr(b-ref1.dscr,i,1).
+        
+            ELSE ASSIGN 
+                    vScore2 = vScore2 + "       ".
+        END.
+        IF AVAILABLE b-ref2 THEN DO i = 1 TO 9:
+            IF AVAILABLE b-ref2 AND b-ref2.val[i] NE 0 THEN ASSIGN 
+                    vScore2 = vScore2 + STRING(TRUNC(b-ref2.val[i],0), ">>>") +
+                                  ":" +
+                                  STRING((b-ref2.val[i] - trunc(b-ref2.val[i],0)) * 100,"99") +
+                                  substr(b-ref2.dscr,i,1).
+        
+            ELSE ASSIGN 
+                    vScore2 = vScore2 + "       ".
+        END.
 
-    /* BLANK WIDTH (MULT OUT) */
-    PUT trunc(po-ordl.s-wid,0)                      FORMAT "999"
-        ":"                                         FORMAT "x"
-        (po-ordl.s-wid - trunc(po-ordl.s-wid,0)) * 16
-                                                    FORMAT "99".
+        /* Blank/Out widths */
+        ASSIGN 
+            vOutWidth = STRING(TRUNC(po-ordl.s-wid,0),"999") + 
+                        ":" + STRING((po-ordl.s-wid - trunc(po-ordl.s-wid,0)) * 16,"99")
+            vBlankWidth = STRING(trunc(po-ordl.s-wid,0),"999") + 
+                        ":" + STRING((po-ordl.s-wid - trunc(po-ordl.s-wid,0)) * 16,"99").
+        /* End Blank/Out widths */
 
-    /* (SF OR SM) PER M */
-    v-ord-qty[2] = v-ord-qty[4] / (v-ord-qty[2] / 1000).
+        /* (SF OR SM) PER M */
+        ASSIGN 
+            v-ord-qty[2] = v-ord-qty[4] / (v-ord-qty[2] / 1000).
+        IF v-ord-qty[2] GT 99999999 THEN v-ord-qty[2] = 99999999.
 
-    IF v-ord-qty[2] GT 99999999 THEN v-ord-qty[2] = 99999999.
+        /* EXT'D (SF OR SM) ORDERED */
+        IF v-ord-qty[4] GT 99999999 THEN v-ord-qty[4] = 99999999.
 
-    PUT v-ord-qty[2]                                FORMAT "99999999".
+        IF hrms-int EQ 0 THEN 
+        DO:
+            /* Use actual i-no for board code and adders */
+            iAdderCount  = 1.
+            /* Board code */
+            iNumericAdder = INTEGER(po-ordl.i-no) NO-ERROR.
+            IF NOT ERROR-STATUS:ERROR THEN ASSIGN 
+                    v-adder[iAdderCount] = STRING(iNumericAdder, "9999")
+                    iAdderCount = iAdderCount + 1.
+            /* Adder codes */
+            EMPTY TEMP-TABLE ttPoAdders.
+            RUN po/getPoAdders.p (INPUT ROWID(po-ordl), INPUT table ttPoAdders BY-REFERENCE).
+            FOR EACH ttPoAdders i = 1 TO 6:
+                iNumericAdder = INTEGER(ttPoAdders.adderCode) NO-ERROR.
+                IF NOT ERROR-STATUS:ERROR THEN ASSIGN 
+                        v-adder[iAdderCount] = STRING(iNumericAdder, "9999")
+                        iAdderCount = iAdderCount + 1.
+            END.
+        END.
+        ELSE IF hrms-int EQ 1 THEN 
+            DO:
+            /* Use HRMS cross-reference table (already done in lines 243-267 */
+            END.
 
-    /* EXT'D (SF OR SM) ORDERED */
-    IF v-ord-qty[4] GT 99999999 THEN v-ord-qty[4] = 99999999.
+        /* SPECIAL INSTRUCTIONS */
+        v-instr = "".
 
-    PUT v-ord-qty[4]                                FORMAT "99999999".
+        FOR EACH notes WHERE notes.rec_key EQ po-ordl.rec_key NO-LOCK:
+            v-instr = v-instr + " " + trim(notes.note_text).
+        END.
+
+        FOR EACH notes WHERE notes.rec_key EQ po-ord.rec_key NO-LOCK:
+            v-instr = v-instr + " " + trim(notes.note_text).
+        END.
+
+        /* Job# */
+        IF po-ordl.job-no NE "" THEN DO:
+            IF hrms-int = 1 THEN ASSIGN 
+                v-jobno = STRING(po-ordl.job-no,"x(6)") + "-" +
+                          STRING(po-ordl.job-no2,"99") + "-" +
+                          v-form.
+            ELSE ASSIGN 
+                v-jobno = STRING(po-ordl.job-no,"x(6)") + "-" +
+                          STRING(po-ordl.job-no2,"99").
+        END.
+        ELSE ASSIGN 
+            v-jobno = "         ".
+
+        /* D1 */
+        PUT 
+            cAssignedCustId     FORMAT "x(5)"       /* CUSTOMER # */
+            "01"                FORMAT "x(2)"       /* 01 */
+            po-ord.po-no        FORMAT "999999"     /* PURCHASE ORDER # */
+            "A"                 FORMAT "x(1)"       /* A */
+            po-ordl.line        FORMAT "99"         /* PURCHASE ORDER # */
+            po-ord.po-no        FORMAT "999999"     /* PURCHASE ORDER # */
+            "A"                 FORMAT "x(1)"       /* A */
+            po-ordl.line        FORMAT "99"         /* PURCHASE ORDER # */
+            FILL(" ",2)         FORMAT "xx"         /* MESSAGE CODE #1 */
+            FILL(" ",2)         FORMAT "xx"         /* MESSAGE CODE #2 */
+            FILL(" ",2)         FORMAT "xx"         /* MESSAGE CODE #3 */
+            FILL(" ",7)         FORMAT "x(7)"       /* 7 blank spaces */
+            "BY"                FORMAT "x(5)"       /* BY */
+            vDueDate            FORMAT "x(6)"       /* DUE DATE */
+            po-ord.over-pct     FORMAT "99"         /* OVERRUN PERCENTAGE */
+            po-ord.under-pct    FORMAT "99"         /* UNDERRUN PERCENTAGE */
+            vWidthInt           FORMAT "999999"     /* INTEGER OF WIDTH */
+            vWidthNum           FORMAT "99"         /* NUMERATOR OF WIDTH */
+            vWidthDen           FORMAT "99"         /* DENOMINATOR OF WIDTH */
+            vWidth              FORMAT "x(6)"       /* WIDTH */
+            vLengthInt          FORMAT "999999"     /* INTEGER OF LENGTH */
+            vLengthNum          FORMAT "99"         /* NUMERATOR OF LENGTH */
+            vLengthDen          FORMAT "99"         /* DENOMINATOR OF LENGTH */
+            vLength             FORMAT "x(6)"       /* LENGTH */
+            vStyleCode          FORMAT "9999"       /* STYLE */
+            vStyleDesc          FORMAT "x(14)"      /* STYLE DESCRIPTION */
+            item.basis-w        FORMAT "9999"       /* WEIGHT OF BOARD */
+            v-ord-qty[1]        FORMAT "99999999"   /* ORDER QUANTITY */
+            FILL(" ",13)        FORMAT "x(13)"      /* 13 blank spaces */     
+            SKIP.
 
 
 
-    iAdderCount  = 1.
-    iNumericAdder = INTEGER(po-ordl.i-no) NO-ERROR.
-    IF NOT ERROR-STATUS:ERROR THEN 
-        ASSIGN v-adder[iAdderCount] = STRING(iNumericAdder, "9999")
-               iAdderCount = iAdderCount + 1
-        .
+        /* D2 */
+        PUT 
+            item.flute          FORMAT "x(3)"       /* ITEM FLUTE */
+            v-ord-cst           FORMAT "9999.99"    /* ORDER COST */
+            v-setup             FORMAT "999.99"     /* SETUP CHARGE */
+            1                   FORMAT "999.99"     /* "001.00" */
+            0                   FORMAT "99999999.9999"  /* "00000000.0000" */
+            v-ord-qty[3]        FORMAT "9999999"    /* ORDERED SF */
+            FILL(" ",46)        FORMAT "x(46)"      /* 46 blank spaces */
+            "X"                 FORMAT "x"          /* "X" */
+            "X"                 FORMAT "x"          /* "X" */
+            po-ordl.i-name      FORMAT "x(30)"      /* DESCRIPTION TEXT */
+            FILL(" ",8)         FORMAT "x(8)"       /* 8 blank spaces */       
+            SKIP.  
 
-    /* Get adder codes */
-    EMPTY TEMP-TABLE ttPoAdders.
-    RUN po/getPoAdders.p (INPUT ROWID(po-ordl), INPUT table ttPoAdders BY-REFERENCE).
-    FOR EACH ttPoAdders i = 1 TO 6:
-        iNumericAdder = INTEGER(ttPoAdders.adderCode) NO-ERROR.
-        IF NOT ERROR-STATUS:ERROR THEN 
-        ASSIGN v-adder[iAdderCount] = STRING(iNumericAdder, "9999")
-        iAdderCount = iAdderCount + 1
-         .
-    END.
-    
-    /* BASE BOARD GRADE CODE */
-    /*
-    FIND FIRST reftable
-        WHERE reftable.reftable EQ "util/b-hrms-x.w"
-          AND reftable.company  EQ po-ordl.company
-          AND reftable.code2    EQ po-ordl.i-no
-        NO-LOCK NO-ERROR.
-    IF AVAIL reftable THEN
-      PUT int(reftable.code)                        FORMAT "9999".
-    ELSE
-      PUT 0                                         FORMAT "9999".
-    */
-    /* Updated this to 7 since reftable code not being output */
-    /* ADDERS */
-    DO i = 1 TO 7:
-      PUT v-adder[i]                                FORMAT "x(4)".
-    END.
+        /* D3 */
+        PUT 
+            po-ordl.i-name      FORMAT "x(128)"     /* ITEM NAME */
+            SKIP.
+        
+        /* D4 */
+        PUT 
+            vScore              FORMAT "x(63)"      /* SCORE */
+            1                   FORMAT "999.99"     /* NUMBER UP */
+            FILL(" ",2)         FORMAT "xx"         /* TRIM */
+            vOutWidth           FORMAT "x(6)"       /* 1 OUT WIDTH, NO TRIM */
+            vBlankWidth         FORMAT "x(6)"       /* BLANK WIDTH (MULT OUT) */
+            v-ord-qty[2]        FORMAT "99999999"   /* (SF OR SM) PER M */
+            v-ord-qty[4]        FORMAT "99999999"   /* EXT'D (SF OR SM) ORDERED */
+            v-adder[1]          FORMAT "x(4)"       /* Board code */
+            v-adder[2]          FORMAT "x(4)"       /* Adders */
+            v-adder[3]          FORMAT "x(4)"       /* Adders */
+            v-adder[4]          FORMAT "x(4)"       /* Adders */
+            v-adder[5]          FORMAT "x(4)"       /* Adders */
+            v-adder[6]          FORMAT "x(4)"       /* Adders */
+            v-adder[7]          FORMAT "x(4)"       /* Adders */
+            FILL(" ",1)         FORMAT "x(1)"       /* Empty space */
+            SKIP.
 
-    /* 1 blank space */
-    PUT FILL(" ",1)                                 FORMAT "x(1)"       SKIP.
-    
-      /* D4 Second instance */
-    
-      /* SCORE */
-      DO i = 10 TO 12:
-          IF AVAIL b-ref1 AND b-ref1.val[i] NE 0 THEN 
-              PUT trunc(b-ref1.val[i],0)                  FORMAT ">>>"
-                  ":"                                     FORMAT "x"
-                  (b-ref1.val[i] - trunc(b-ref1.val[i],0)) * 100
-                  FORMAT "99"
-                  substr(b-ref1.dscr,i,1)                 FORMAT "x".
-            
-          ELSE PUT "       "                            FORMAT "x(7)".
-      END.
-      
-      IF AVAILABLE b-ref2 THEN DO:
-          DO i = 1 TO 9:
-              IF AVAIL b-ref2 AND b-ref2.val[i] NE 0 THEN 
-                  PUT trunc(b-ref2.val[i],0)                  FORMAT ">>>"
-                      ":"                                     FORMAT "x"
-                      (b-ref2.val[i] - trunc(b-ref2.val[i],0)) * 100
-                      FORMAT "99"
-                      substr(b-ref2.dscr,i,1)                 FORMAT "x".
-                
-              ELSE PUT "       "                            FORMAT "x(7)".
-          END.
-      END.
-      PUT FILL(" ",1)                                 FORMAT "x(1)"       SKIP.
-      
-    /* D5 */
+        /* D4 Second instance */
+        PUT 
+            vscore2             FORMAT "x(84)"      /* Additional Scores */
+            FILL(" ",1)         FORMAT "x(1)"       /* Blank space */       
+            SKIP.
+  
+        /* D5 */
+        /* Tri-lakes / EFI */
+        IF hrms-int EQ 1 THEN PUT 
+            v-instr             FORMAT "x(64)"      /* Notes */
+            v-jobno             FORMAT "x(12)"       /* Job No */
+            FILL(" ",52)        FORMAT "x(55)"       
+            SKIP.
+        /* Valley */
+        ELSE PUT 
+            v-instr             FORMAT "x(64)"      /* Notes */
+            v-jobno             FORMAT "x(9)"       /* Job No */
+            FILL(" ",55)        FORMAT "x(55)"       
+            SKIP.
 
-    /* SPECIAL INSTRUCTIONS */
-    v-instr = "".
+    END. /* for each po-ordl record */
 
-    FOR EACH notes WHERE notes.rec_key EQ po-ordl.rec_key NO-LOCK:
-      v-instr = v-instr + " " + trim(notes.note_text).
-    END.
+    FIND bpo-ord EXCLUSIVE WHERE 
+        ROWID(bpo-ord) = ROWID(po-ord).
+    ASSIGN 
+        bpo-ord.printed = YES.
 
-    FOR EACH notes WHERE notes.rec_key EQ po-ord.rec_key NO-LOCK:
-      v-instr = v-instr + " " + trim(notes.note_text).
-    END.
+    IF SEARCH(v-outfile[2]) NE ? THEN 
+    DO:
+        OUTPUT close.
 
-    PUT v-instr                                     FORMAT "x(64)".
-
-    /* Job# */
-    IF po-ordl.job-no NE "" THEN
-      PUT STRING(po-ordl.job-no,"x(6)") + "-" +
-          string(po-ordl.job-no2,"99")              FORMAT "x(9)".
-    ELSE
-      PUT FILL(" ",9)                               FORMAT "x(9)".
-
-    /* 64 blank spaces */
-    PUT FILL(" ",55)                                FORMAT "x(55)"       SKIP.
-  END. /* for each po-ordl record */
-
-  po-ord.printed = YES.
-
-  IF SEARCH(v-outfile[2]) NE ? THEN DO:
-    OUTPUT close.
-    
-    IF OPSYS EQ "unix" THEN
-      UNIX SILENT QUOTER -c 1-3000 VALUE(v-outfile[2]) >
-                                   VALUE(v-outfile[2] + ".quo").
-    ELSE
-      DOS  SILENT QUOTER -c 1-3000 VALUE(v-outfile[2]) >
-                                   VALUE(v-outfile[2] + ".quo").
-                                   
-    INPUT from value(v-outfile[2] + ".quo").
-    
-    OUTPUT to value(v-outfile[4]).
-    
-    REPEAT:
-      v-line = FILL(" ",128).
-      IMPORT v-line.
-      PUT v-line FORMAT "x(128)" SKIP.
-    END.
-    
-    OUTPUT close.
-    
-    INPUT close.
-    
-    IF OPSYS EQ "unix" THEN
-      UNIX SILENT rm VALUE(v-outfile[2] + "*.*").
-    ELSE
-      DOS SILENT DEL VALUE(v-outfile[2] + "*.*").
-      
-    RUN po/ftppo.p (v-outfile[4],"HRMS"). 
-    MESSAGE "HRMS file:" TRIM(v-outfile[3]) "has been created" 
+        OS-COPY VALUE(v-outfile[2]) VALUE(v-outfile[4]).
+        OS-DELETE VALUE(v-outfile[2]).
+  
+        RUN po/ftppo.p (v-outfile[4],"HRMS"). 
+        MESSAGE "HRMS file:" TRIM(v-outfile[3]) "has been created" 
             VIEW-AS ALERT-BOX.
-cWinScpXmlLog = v-outfile[4] + ".xml".
-   run checkXmlLogResult.            
-  END.
+        cWinScpXmlLog = v-outfile[4] + ".xml".
+        RUN checkXmlLogResult.            
+    END.
 
-  PAUSE 1 NO-MESSAGE.
+    PAUSE 1 NO-MESSAGE.
 END. /* for each po-ord record */
 
 PROCEDURE checkXmlLogResult:
     DEFINE VARIABLE cLogLine AS CHARACTER NO-UNDO.
     DEFINE VARIABLE lTransferSuccess AS LOGICAL NO-UNDO.
+
     lTransferSuccess = FALSE.
     // To ensure process has finished
-    pause 1. 
+    PAUSE 1. 
     IF SEARCH(cWinscpXmlLog) NE ? THEN DO:
         lTransferSuccess = FALSE.
         INPUT STREAM sReadLog FROM VALUE(SEARCH(cWinscpXmlLog)).
         REPEAT:
             cLogLine = "".
             IMPORT STREAM sReadLog UNFORMATTED cLogLine.
-            IF INDEX(cLogLine, "Result") GT 0 AND INDEX(cLogLine, "success") GT 0 THEN DO:
-                IF INDEX(cLogLine, "true") GT 0 THEN DO:
+            IF INDEX(cLogLine, "Result") GT 0 AND INDEX(cLogLine, "success") GT 0 THEN 
+            DO:
+                IF INDEX(cLogLine, "true") GT 0 THEN 
+                DO:
                     lTransferSuccess = TRUE.
                 END.
             END. 
         END. /* repeat */
         INPUT STREAM sReadLog CLOSE.
-
-
-        
     END.
-    output stream sLogFileTest to value("n:\environments\prod\custfiles\logs\TestXmlLog.txt") append.
-    put stream sLogFileTest unformatted cWinScpXmlLog " " string(lTransferSuccess) skip.
+    OUTPUT stream sLogFileTest to value("n:\environments\prod\custfiles\logs\TestXmlLog.txt") append.
+    PUT STREAM sLogFileTest UNFORMATTED cWinScpXmlLog " " STRING(lTransferSuccess) SKIP.
     
-            IF NOT lTransferSuccess THEN 
-           MESSAGE "Warning: The purchase order was not transmitted."
-                   VIEW-AS ALERT-BOX.
-    output stream sLogFileTest close.
+    IF NOT lTransferSuccess THEN 
+        MESSAGE "Warning: The purchase order was not transmitted."
+            VIEW-AS ALERT-BOX.
+    OUTPUT stream sLogFileTest close.
 END PROCEDURE.
-/* end ----------------------------------- Copr. 2004  Advanced Software Inc. */
+

--- a/Source/po/po-hrexp.p
+++ b/Source/po/po-hrexp.p
@@ -390,6 +390,8 @@ FOR EACH report NO-LOCK WHERE
         /* END ORDERED SF */
 
         /* SCORE */
+        ASSIGN 
+            vScore = "".
         DO i = 1 TO 9:
             IF AVAILABLE b-ref1 AND b-ref1.val[i] NE 0 THEN ASSIGN 
                     vScore = vScore + STRING(TRUNC(b-ref1.val[i],0), ">>>") +
@@ -403,6 +405,8 @@ FOR EACH report NO-LOCK WHERE
         /* END SCORE */
         
         /* Additional Scores */
+        ASSIGN 
+            vscore2 = "".
         DO i = 10 TO 12:
             IF AVAILABLE b-ref1 AND b-ref1.val[i] NE 0 THEN ASSIGN 
                     vScore2 = vScore2 + STRING(TRUNC(b-ref1.val[i],0), ">>>") +

--- a/Source/sys/inc/gp.i
+++ b/Source/sys/inc/gp.i
@@ -2,6 +2,7 @@
 DEF VAR gp-dir LIKE sys-ctrl.descrip NO-UNDO.
 DEF VAR gp-log LIKE sys-ctrl.log-fld NO-UNDO.
 DEF VAR gp-cha LIKE sys-ctrl.char-fld NO-UNDO.
+DEF VAR gp-int LIKE sys-ctrl.int-fld NO-UNDO.
 
 
 {sys/inc/poexport.i}
@@ -21,4 +22,7 @@ end.
 assign
  gp-dir = sys-ctrl.descrip
  gp-log = sys-ctrl.log-fld
- gp-cha = sys-ctrl.char-fld.
+ gp-cha = sys-ctrl.char-fld
+ gp-int = sys-ctrl.int-fld.
+ 
+

--- a/Source/sys/inc/hrms.i
+++ b/Source/sys/inc/hrms.i
@@ -1,6 +1,7 @@
 
 DEF VAR hrms-dir LIKE sys-ctrl.descrip NO-UNDO.
 DEF VAR hrms-log LIKE sys-ctrl.log-fld NO-UNDO.
+DEF VAR hrms-int LIKE sys-ctrl.int-fld NO-UNDO.
 
 
 {sys/inc/poexport.i}
@@ -19,5 +20,6 @@ if not avail sys-ctrl then do:
 end.
 assign
  hrms-dir = sys-ctrl.descrip
- hrms-log = sys-ctrl.log-fld.
+ hrms-log = sys-ctrl.log-fld
+ hrms-int = sys-ctrl.int-fld. 
 

--- a/Source/sys/ref/sys-ctrl.i
+++ b/Source/sys/ref/sys-ctrl.i
@@ -183,9 +183,9 @@ ASSIGN
  str-init[91] = "MSF,PO UOM"  /*appaper*/
  str-init[92] = "FluteMtx,AUTOCALC"  /*appaper*/
  str-init[93] = ",Before,After,Both"  /*fgpost*/
- str-init[94] = ",CSC,Southpak,TrePaper"  /* corsuply */
+ str-init[94] = ",CSC,SouthpHak,TrePaper"  /* corsuply */
  str-init[95] = "Blank,GrossSH"  /* fgitemsf */
- str-init[96] = ",Michcor,Trilakes,Woodland,PremierPkg,St.Clair,NStock,Blue,Freedman"  /* GP */
+ str-init[96] = ",Michcor,Trilakes,Woodland,PremierPkg,St.Clair,NStock,Blue,Freedman,Shamrock"  /* GP */
  str-init[97] = "DC Only,OE & DC"   /* oeprep */
  str-init[98] = "None,1/8,1/8Up,1/4,1/4Up,1/2,1/2Up,1,1Up"  /* celayout */
  str-init[99] = "Fibre"


### PR DESCRIPTION
Programs changed:
po/po-hrexp.p
- almost a complete rewrite
- driving issue was lack of reference to hrms reftable (removed as unneeded for valley)
- put this back, plus minor changes from conversations with EFI, Welch, TriLakes
sys/inc/hrms.i
- added reference to NK1 "HRMS" integer value
- must be set to "1" to use reftable; this to prevent unplanned changes to Valley transmissions