### PR TITLE
67059 User Locks - 1

### DIFF
--- a/Source/custom/rec_key.i
+++ b/Source/custom/rec_key.i
@@ -15,3 +15,5 @@ ELSE DO:
                 .
     RUN custom/RecKeyLog.p ("{1}").
 END. /* else */
+/* Resolves hanging EXCLUSIVE lock issue whenever a record is created */
+FIND CURRENT rec_key NO-LOCK NO-ERROR.


### PR DESCRIPTION
File changed: custom/rec_key.i
Added FIND NO-LOCK to rec_key record after created
This include is called by every create trigger and leaves a hanging EXCLUSIVE lock on rec_key
By itself, this is not a critical issue, but shows lots of entries in LockMonitor