### PR TITLE
69898 Incorrect cost in PU1

### DIFF
--- a/Source/po/d-poordl.w
+++ b/Source/po/d-poordl.w
@@ -5883,7 +5883,9 @@ PROCEDURE valid-ord-no :
         
             FIND FIRST oe-ord NO-LOCK
                 WHERE oe-ord.company EQ cocode
-                AND oe-ord.ord-no  EQ INT(po-ordl.ord-no:SCREEN-VALUE) NO-ERROR.
+                AND oe-ord.ord-no  EQ INT(po-ordl.ord-no:SCREEN-VALUE) 
+                AND oe-ord.ord-no NE 0 
+                NO-ERROR.
             IF AVAILABLE oe-ord 
                 THEN
                 ASSIGN

--- a/Source/po/d-poordlN.w
+++ b/Source/po/d-poordlN.w
@@ -6554,7 +6554,6 @@ PROCEDURE vend-cost :
         END.  /* IF po-ordl.item-type:SCREEN-VALUE EQ "RM" */
         ELSE 
         DO:  /* for "FG" */
-        MESSAGE "ok" SKIP po-ordl.cust-no:SCREEN-VALUE VIEW-AS ALERT-BOX.
             FIND itemfg NO-LOCK 
                 WHERE itemfg.company EQ cocode
                 AND itemfg.i-no EQ po-ordl.i-no:SCREEN-VALUE
@@ -6581,18 +6580,15 @@ PROCEDURE vend-cost :
                 OUTPUT dCostTotal, 
                 OUTPUT lError, 
                 OUTPUT cMessage).        
-MESSAGE dCostPerUOM SKIP lerror SKIP cmessage VIEW-AS ALERT-BOX.
             RUN Conv_ValueFromUOMtoUOM(cocode, 
                 po-ordl.i-no:SCREEN-VALUE, "FG", 
                 dCostPerUOM, cCostUOM, po-ordl.cons-uom:SCREEN-VALUE, 
                 0, DECIMAL(po-ordl.s-len:SCREEN-VALUE),DECIMAL(po-ordl.s-wid:SCREEN-VALUE),DECIMAL(v-po-dep:SCREEN-VALUE),0, 
                 OUTPUT dCostPerUOMCons, OUTPUT lError, OUTPUT cMessage).
- MESSAGE dCostPerUOMCons SKIP lerror SKIP cmessage VIEW-AS ALERT-BOX.
              
         END. /* if item-type ne RM */
         IF ip-calc-cost THEN 
         DO:   
-MESSAGE "ip-calc-cost" VIEW-AS ALERT-BOX.            
             ASSIGN 
                 po-ordl.cost:SCREEN-VALUE      = STRING(dCostPerUOM,po-ordl.cost:FORMAT)
                 po-ordl.setup:SCREEN-VALUE     = STRING(dCostSetup,po-ordl.setup:FORMAT)

--- a/Source/po/d-poordlN.w
+++ b/Source/po/d-poordlN.w
@@ -6074,7 +6074,9 @@ PROCEDURE valid-ord-no :
         
             FIND FIRST oe-ord NO-LOCK
                 WHERE oe-ord.company EQ cocode
-                AND oe-ord.ord-no  EQ INT(po-ordl.ord-no:SCREEN-VALUE) NO-ERROR.
+                AND oe-ord.ord-no  EQ INT(po-ordl.ord-no:SCREEN-VALUE) 
+                AND oe-ord.ord-no NE 0
+                NO-ERROR.
             IF AVAILABLE oe-ord 
                 THEN
                 ASSIGN
@@ -6552,6 +6554,7 @@ PROCEDURE vend-cost :
         END.  /* IF po-ordl.item-type:SCREEN-VALUE EQ "RM" */
         ELSE 
         DO:  /* for "FG" */
+        MESSAGE "ok" SKIP po-ordl.cust-no:SCREEN-VALUE VIEW-AS ALERT-BOX.
             FIND itemfg NO-LOCK 
                 WHERE itemfg.company EQ cocode
                 AND itemfg.i-no EQ po-ordl.i-no:SCREEN-VALUE
@@ -6578,15 +6581,18 @@ PROCEDURE vend-cost :
                 OUTPUT dCostTotal, 
                 OUTPUT lError, 
                 OUTPUT cMessage).        
+MESSAGE dCostPerUOM SKIP lerror SKIP cmessage VIEW-AS ALERT-BOX.
             RUN Conv_ValueFromUOMtoUOM(cocode, 
                 po-ordl.i-no:SCREEN-VALUE, "FG", 
                 dCostPerUOM, cCostUOM, po-ordl.cons-uom:SCREEN-VALUE, 
                 0, DECIMAL(po-ordl.s-len:SCREEN-VALUE),DECIMAL(po-ordl.s-wid:SCREEN-VALUE),DECIMAL(v-po-dep:SCREEN-VALUE),0, 
                 OUTPUT dCostPerUOMCons, OUTPUT lError, OUTPUT cMessage).
+ MESSAGE dCostPerUOMCons SKIP lerror SKIP cmessage VIEW-AS ALERT-BOX.
              
         END. /* if item-type ne RM */
         IF ip-calc-cost THEN 
         DO:   
+MESSAGE "ip-calc-cost" VIEW-AS ALERT-BOX.            
             ASSIGN 
                 po-ordl.cost:SCREEN-VALUE      = STRING(dCostPerUOM,po-ordl.cost:FORMAT)
                 po-ordl.setup:SCREEN-VALUE     = STRING(dCostSetup,po-ordl.setup:FORMAT)


### PR DESCRIPTION
Program changed: po/d-poordl
if a cust no was entered, AND there is a order in the DB with ord-no EQ 0, the cust-no was being blanked out during the SAVE process.
Cost is being properly imported from the e-itemfg record for the specified customer in current code.