### PR TITLE
68728 Update to to check disk space prior to starting backup

### DIFF
--- a/Deployment/BuildScript/ToCompile/asiUpdateDB.w
+++ b/Deployment/BuildScript/ToCompile/asiUpdateDB.w
@@ -38,6 +38,7 @@ DEF INPUT PARAMETER ipiPatchDbVer AS INT NO-UNDO.
 DEF INPUT PARAMETER ipiCurrAudVer AS INT NO-UNDO.
 DEF INPUT PARAMETER ipiPatchAudVer AS INT NO-UNDO.
 DEF INPUT PARAMETER ipiLevel AS INT NO-UNDO.
+DEF INPUT PARAMETER iplMakeBackup AS LOG NO-UNDO.
 DEF OUTPUT PARAMETER oplSuccess AS LOG NO-UNDO.
 DEF INPUT-OUTPUT PARAMETER iopiStatus AS INT NO-UNDO.
 
@@ -906,13 +907,15 @@ PROCEDURE ipProcessRequest :
         RUN ipReadAdminSvcProps.    
 
     /* Process "regular" database (asixxxx.db OR XXXXXXd.db) */
-    RUN ipBackupDBs.
-    IF NOT lSuccess THEN 
-    DO:
-        ASSIGN 
-            oplSuccess = FALSE.
-        RUN ipStatus ("  Upgrade failed in ipBackupDBs for database " + fiDbName:{&SV}).
-        RETURN.
+    IF iplMakeBackup THEN DO:
+        RUN ipBackupDBs.
+        IF NOT lSuccess THEN 
+        DO:
+            ASSIGN 
+                oplSuccess = FALSE.
+            RUN ipStatus ("  Upgrade failed in ipBackupDBs for database " + fiDbName:{&SV}).
+            RETURN.
+        END.
     END.
     
     RUN ipUpgradeDBs.


### PR DESCRIPTION
Programs changed:
asiUpdate.w - added code to calculate available disk space, estimate size of db backups, and stop/advise if more disk space is needed
- 90% of this code copied from asiDbMaint.w, where it has been working for about a year
- also added "hidden" ability to turn off automatic DB backups when SupportRep (me) is running the upgrade