### PR TITLE
60354 Unlicensed Auditing

### DIFF
--- a/Deployment/BuildScript/ToCompile/asiAuditTest.p
+++ b/Deployment/BuildScript/ToCompile/asiAuditTest.p
@@ -13,10 +13,4 @@ IF AVAIL module THEN ASSIGN
 IF CAN-FIND(FIRST _file WHERE _file._file-name EQ "dep-table") THEN ASSIGN 
     oplHasTables = TRUE.
     
-OUTPUT TO c:\tmp\auditTbl.d.
-FOR EACH auditTbl:
-    EXPORT auditTbl.
-END.  
-OUTPUT CLOSE.
-
 

--- a/Deployment/BuildScript/ToCompile/asiAuditTest.p
+++ b/Deployment/BuildScript/ToCompile/asiAuditTest.p
@@ -12,5 +12,11 @@ IF AVAIL module THEN ASSIGN
 
 IF CAN-FIND(FIRST _file WHERE _file._file-name EQ "dep-table") THEN ASSIGN 
     oplHasTables = TRUE.
+    
+OUTPUT TO c:\tmp\auditTbl.d.
+FOR EACH auditTbl:
+    EXPORT auditTbl.
+END.  
+OUTPUT CLOSE.
 
 

--- a/Deployment/BuildScript/ToCompile/asiUpdateEnv.w
+++ b/Deployment/BuildScript/ToCompile/asiUpdateEnv.w
@@ -3452,6 +3452,14 @@ PROCEDURE ipDeleteAudit :
                 AuditTbl.AuditUpdate = NO
                 AuditTbl.AuditStack  = NO.
         END.
+        IF SEARCH("c:\tmp\auditTbl.e") NE ? THEN DO:  /* Recover the auditTbl file dropped during updateDB audit check */
+            INPUT FROM c:\tmp\auditTbl.d.
+            REPEAT:
+                IMPORT AuditTbl.
+            END.
+            INPUT CLOSE.
+            OS-DELETE c:\tmp\auditTbl.d.
+        END.
     END.
     ELSE DO:
         RUN ipStatus ("    Deleting audit records older than 180 days...").
@@ -4091,6 +4099,23 @@ PROCEDURE ipLoadAuditRecs :
                 CREATE {&tablename}.
                 BUFFER-COPY tt{&tablename} TO {&tablename}.
             END.
+            /* Ensure OUR defaults are set */
+            ASSIGN 
+                {&tableName}.auditCreateDefault = tt{&tableName}.auditCreateDefault
+                {&tableName}.auditUpdateDefault = tt{&tableName}.auditUpdateDefault
+                {&tableName}.auditDeleteDefault = tt{&tableName}.auditDeleteDefault
+                {&tableName}.auditStackDefault = tt{&tableName}.auditStackDefault
+                {&tableName}.ExpireDaysDefault = tt{&tableName}.ExpireDaysDefault
+                .
+            /* and make sure THEIR activation is AT LEAST the default */
+            ASSIGN 
+                {&tableName}.auditCreate = IF {&tableName}.auditCreateDefault THEN TRUE ELSE {&tableName}.auditCreate
+                {&tableName}.auditUpdate = IF {&tableName}.auditUpdateDefault THEN TRUE ELSE {&tableName}.auditUpdate
+                {&tableName}.auditDelete = IF {&tableName}.auditDeleteDefault THEN TRUE ELSE {&tableName}.auditDelete
+                {&tableName}.auditStack = IF {&tableName}.auditStackDefault THEN TRUE ELSE {&tableName}.auditStack
+                {&tableName}.expireDays = IF {&tableName}.ExpireDaysDefault NE 0 THEN {&tableName}.ExpireDaysDefault ELSE {&tableName}.ExpireDays
+                . 
+            
         END.
     END.
     INPUT CLOSE.

--- a/Deployment/BuildScript/ToCompile/asiUpdateEnv.w
+++ b/Deployment/BuildScript/ToCompile/asiUpdateEnv.w
@@ -3452,14 +3452,6 @@ PROCEDURE ipDeleteAudit :
                 AuditTbl.AuditUpdate = NO
                 AuditTbl.AuditStack  = NO.
         END.
-        IF SEARCH("c:\tmp\auditTbl.e") NE ? THEN DO:  /* Recover the auditTbl file dropped during updateDB audit check */
-            INPUT FROM c:\tmp\auditTbl.d.
-            REPEAT:
-                IMPORT AuditTbl.
-            END.
-            INPUT CLOSE.
-            OS-DELETE c:\tmp\auditTbl.d.
-        END.
     END.
     ELSE DO:
         RUN ipStatus ("    Deleting audit records older than 180 days...").


### PR DESCRIPTION
Files changed:
asiAuditTest.p - if not licensed for audit, create dump file of auditTbl records that are later recovered in asiUpdateEnv.w
asiUpdateEnv.w - recover the dumped records if necessary, ensure default fields are added and honored