### PR TITLE
70792 VU1-Invoice Entry Issue

### DIFF
--- a/Source/ap/b-apinvl.w
+++ b/Source/ap/b-apinvl.w
@@ -2941,6 +2941,7 @@ PROCEDURE valid-po-no :
   Notes:       
 ------------------------------------------------------------------------------*/
   DEF VAR lv-msg AS CHAR NO-UNDO.
+  DEF VAR lv-msg2 AS CHAR NO-UNDO.
   DEFINE VARIABLE lMessage AS LOGICAL NO-UNDO.
   DEF BUFFER b-ap-invl FOR ap-invl.
   
@@ -2962,18 +2963,28 @@ PROCEDURE valid-po-no :
              ROWID(b-ap-invl) EQ ROWID(ap-invl)
              NO-LOCK NO-ERROR.
 
-        FOR EACH po-ordl NO-LOCK
-            WHERE po-ordl.company EQ po-ord.company
-              AND po-ordl.po-no   EQ po-ord.po-no:
-              IF po-ordl.t-rec-qty EQ 0 THEN DO:
+        FOR EACH po-ordl NO-LOCK WHERE 
+            po-ordl.company EQ po-ord.company AND 
+            po-ordl.po-no   EQ po-ord.po-no:
+            IF po-ordl.t-rec-qty EQ 0 THEN DO:
                 MESSAGE  "Do you want to verify receipt .. "
                           VIEW-AS ALERT-BOX QUESTION BUTTONS YES-NO                  
                 UPDATE lMessage.
                 IF lMessage THEN 
-                RUN pReCalculateRecQty.
-              END.                 
-          RUN ap/valid-po2.p (BUFFER po-ordl, BUFFER b-ap-invl ,OUTPUT lv-msg).
-          IF AVAIL po-ordl THEN LEAVE.
+                    RUN pReCalculateRecQty.
+            END.                 
+            RUN ap/valid-po2.p (BUFFER po-ordl, BUFFER b-ap-invl ,OUTPUT lv-msg2).
+            IF lv-msg2 NE "" THEN DO:
+                MESSAGE TRIM(lv-msg2) VIEW-AS ALERT-BOX WARNING UPDATE lContinue AS LOG.
+                ASSIGN 
+                    lv-msg2 = "".
+                IF NOT lContinue THEN DO:
+                    APPLY "entry" TO ap-invl.po-no.
+                    RETURN ERROR.
+                END.
+            END.
+                
+            IF AVAIL po-ordl THEN LEAVE.
         END.
         IF NOT AVAIL po-ordl AND lv-msg EQ "" THEN lv-msg = "No Receipts exist for this PO".
       END.

--- a/Source/ap/valid-po2.p
+++ b/Source/ap/valid-po2.p
@@ -5,6 +5,9 @@ DEFINE OUTPUT PARAMETER opcOutError AS CHARACTER NO-UNDO .
 DEF BUFFER b-po-ord FOR po-ord.
 DEF VAR v-negative-receipt AS LOG NO-UNDO.
 DEF VAR v-po-no AS CHAR NO-UNDO.
+DEF VAR iCtr AS INT NO-UNDO.
+DEF VAR tInvoicedQty AS DEC NO-UNDO.
+DEF VAR cUoM AS CHAR NO-UNDO.
 
 IF AVAIL io-po-ordl AND io-po-ordl.t-rec-qty EQ 0 AND
    NOT(io-po-ordl.item-type AND
@@ -57,31 +60,37 @@ DO:
       END.
 END.
 
-IF AVAIL io-po-ordl                                             AND                                 
-  io-po-ordl.stat      NE "X"   /* not deleted or cancelled */  AND            
-  io-po-ordl.stat      NE "F"   /* not deleted or cancelled */  AND            
-  (io-po-ordl.t-rec-qty NE 0 OR v-negative-receipt OR
-   (io-po-ordl.item-type AND
-    CAN-FIND(FIRST item
-             WHERE item.company EQ io-po-ordl.company
-               AND item.i-no    EQ io-po-ordl.i-no
-               AND item.i-code  EQ "R"
-               AND item.stocked EQ NO
-             USE-INDEX i-no)))                                  THEN.
+IF AVAIL io-po-ordl 
+AND io-po-ordl.stat NE "X"   /* not deleted or cancelled */  
+AND io-po-ordl.stat NE "F"   /* not deleted or cancelled */  
+AND (io-po-ordl.t-rec-qty NE 0 
+    OR v-negative-receipt 
+    OR (io-po-ordl.item-type AND CAN-FIND(FIRST item WHERE 
+        item.company EQ io-po-ordl.company AND 
+        item.i-no    EQ io-po-ordl.i-no AND 
+        item.i-code  EQ "R" AND 
+        item.stocked EQ NO
+        USE-INDEX i-no)))
+        THEN.
 ELSE RELEASE io-po-ordl.
 
- FIND FIRST ap-invl no-lock
-      WHERE ap-invl.company EQ io-po-ordl.company
-      AND ap-invl.po-no  EQ io-po-ordl.po-no
-      AND {ap/invlline.i -1} EQ io-po-ordl.line
-      AND ROWID(ap-invl)     NE ROWID(io-ap-invl) NO-ERROR .
-IF AVAIL ap-invl THEN
-DO:
-  RELEASE io-po-ordl.
-   FIND FIRST ap-inv WHERE ap-inv.i-no EQ ap-invl.i-no NO-LOCK NO-ERROR.
-   IF AVAIL ap-inv AND ap-inv.posted EQ YES THEN
-    opcOutError = "The PO has already been Invoiced.                                       " + "Invoice: " + STRING(ap-inv.inv-no) + "    Date: " + STRING(ap-inv.inv-date) . 
-   ELSE IF AVAIL ap-inv AND ap-inv.posted EQ NO THEN
-    opcOutError = "The PO receipt already added on Invoiced.                           " + "Invoice: " + STRING(ap-inv.inv-no) + "    Date: " + STRING(ap-inv.inv-date) .  
+/* Scan for existing invoice lines for this PO line */
+FOR EACH ap-invl NO-LOCK WHERE
+    ap-invl.company EQ io-po-ordl.company AND 
+    ap-invl.po-no EQ io-po-ordl.po-no AND 
+    {ap/invlline.i -1} EQ io-po-ordl.line AND 
+    ROWID(ap-invl) NE ROWID(io-ap-invl):
+    ASSIGN 
+        iCtr = iCtr + 1
+        tInvoicedQty = tInvoicedQty + ap-invl.qty
+        cUoM = ap-invl.pr-qty-uom.
+END.
+
+/* If the invoiced total qty plus this (input) qty GT PO line qty, show a warning */
+IF tInvoicedQty + io-ap-invl.qty GT io-po-ordl.ord-qty THEN DO:
+    RELEASE io-po-ordl.
+    ASSIGN 
+        opcOutError = "There are already " + STRING(iCtr) + " AP invoices for this PO line totalling " +
+                      STRING(tInvoicedQty) + " units (" + cUoM + "). Do you want to continue?". 
 END.
       


### PR DESCRIPTION
Files changed:
ap/b-apinvl.w - 2977-2987 - allow display of message as warning, with ability to bypass
ap/valid-po2.p - changed logic to calculate total (previously) invoiced qtys and only issue message if previous+current exceeds PO line qty