### PR TITLE
71492 O-U-4 - Not rendering results

### DIFF
--- a/Source/oerep/r-acknow.w
+++ b/Source/oerep/r-acknow.w
@@ -3110,6 +3110,8 @@ END.
 
 RUN custom/usrprint.p (v-prgmname, FRAME {&FRAME-NAME}:HANDLE).
 
+FIND CURRENT oe-ord NO-LOCK NO-ERROR.
+
 SESSION:SET-WAIT-STATE("").
 /* end ---------------------------------- copr. 2001 Advanced Software, Inc. */
 


### PR DESCRIPTION
File changed: oerep/r-acknow.w
added FIND NO-LOCK on oe-ord at end of run-proc procedure.
individual acks were setting print-ack flag, creating a share-lock that was not resolved