### PR TITLE
69898 Incorrect cost in PU1

### DIFF
--- a/Source/system/VendorCostProcs.p
+++ b/Source/system/VendorCostProcs.p
@@ -1724,6 +1724,13 @@ PROCEDURE pGetVendItemCostBuffer PRIVATE:
                 ELSE 
                 DO: /*Fall back options for PO*/
                     cMsgInputs = cMsgFGInputs.
+                    FIND FIRST opbf-vendItemCost NO-LOCK /*Match with blank est and non-blank customer*/
+                        {&RequiredCriteria}
+                        AND opbf-vendItemCost.estimateNo EQ ""
+                        AND opbf-vendItemCost.vendorID EQ ipcVendorID
+                        AND opbf-vendItemCost.customerID EQ ipcCustomerID
+                        NO-ERROR.
+                    IF NOT AVAILABLE opbf-vendItemCost THEN 
                     FIND FIRST opbf-vendItemCost NO-LOCK /*Match with blank customer*/
                         {&RequiredCriteria}
                         AND opbf-vendItemCost.estimateNo EQ ""


### PR DESCRIPTION
Program changed: system/vendorCostProcs.p
added fallback on FG items to find price if est-no is blank and cust-no is non-blank