### PR TITLE
85666 cXML Monitor throws procedure error on multi-line orders

### DIFF
--- a/Source/cXML/cXMLOrderProc.i
+++ b/Source/cXML/cXMLOrderProc.i
@@ -651,9 +651,9 @@ PROCEDURE genOrderLines:
       RELEASE reftable.
       RELEASE oe-ord-whs-order.
       RELEASE oe-ordl-whs-item.
-      DELETE OBJECT hdCostProcs.
   END. /* for each  */
   
+  DELETE OBJECT hdCostProcs.
   RELEASE reftable.
   RELEASE oe-ord-whs-order.
   RELEASE oe-ordl-whs-item.


### PR DESCRIPTION
Files changed:
cXML\cXMLOrderProc.i
object handle being released at wrong point in procedure
Note: discovered at Premier immediately following 20.02.01 upgrade.
Installed fix on Prem TEST, Prem LIVE, Ptree TEST, Ptree LIVE
Added to 20.02.01 patch