### PR TITLE
91793 POEXPORT - Multiple configurations for same vendor

### DIFF
--- a/Source/po/ftppo.p
+++ b/Source/po/ftppo.p
@@ -502,6 +502,24 @@ IF AVAIL sys-ctrl THEN DO:
         OUTPUT CLOSE.
      END. /* AlliFlutes */
    
+     ELSE IF ip-ftp-where EQ "AlliFlutes1" THEN DO:
+        OUTPUT TO VALUE(cPoConfigDir + "\ftpaf.txt").    /* ftp text file */
+        IF lConfigBased THEN DO:
+            lConfigIdentified = TRUE.
+            FIND FIRST ttConfig 
+                WHERE ttConfig.exportFormat EQ ip-ftp-where
+                AND ttConfig.destName EQ sys-ctrl.char-fld
+                NO-LOCK NO-ERROR.
+
+            IF AVAIL ttconfig THEN 
+            DO:     
+                OUTPUT CLOSE.
+                RUN config-based-script.
+            END.
+        END.
+        OUTPUT CLOSE.
+    END. /* AlliFlutes */
+
     /* ip-ftp-where was not listed */
     IF NOT lConfigIdentified THEN DO:
         

--- a/Source/porep/r-poprt.w
+++ b/Source/porep/r-poprt.w
@@ -59,9 +59,9 @@ DEFINE VARIABLE ls-fax-file       AS CHARACTER NO-UNDO.
 DEFINE VARIABLE lv-multi-faxout   AS LOG  NO-UNDO.
 DEFINE VARIABLE lv-fax-image      AS CHARACTER NO-UNDO.
 DEFINE VARIABLE lv-pdf-file       AS CHARACTER NO-UNDO.
-DEFINE VARIABLE lv-exp-form-list  AS CHARACTER NO-UNDO INIT "CorrTrim,Alliance,HRMS,CorSuply,Corr-U-KraftII,GP,Kiwi,Smurfit,CorrChoice,Pratt,AlliFlutes,iPaper,Kiwit,Liberty".
+DEFINE VARIABLE lv-exp-form-list  AS CHARACTER NO-UNDO INIT "CorrTrim,Alliance,HRMS,CorSuply,Corr-U-KraftII,GP,Kiwi,Smurfit,CorrChoice,Pratt,AlliFlutes,AlliFlutes1,iPaper,Kiwit,Liberty".
 DEFINE VARIABLE lv-exp-prog-list  AS CHARACTER NO-UNDO INIT "po-ctexp,po-alexp,po-hrexp,po-csexp,po-ckexp,po-gpexp,po-kwexp,po-smurfi,po-ccexp,po-prexp,~
-po-alnceexp,po-ipaper,po-ktexp,po-librt".
+po-alnceexp,po-alnceexp,po-ipaper,po-ktexp,po-librt".
 DEFINE VARIABLE vcDefaultForm     AS CHARACTER NO-UNDO.
 DEFINE VARIABLE lv-fax-type       AS CHARACTER NO-UNDO.
 DEFINE VARIABLE lv-attachments    AS LOG  NO-UNDO.

--- a/Source/sys/ref/sys-ctrl.i
+++ b/Source/sys/ref/sys-ctrl.i
@@ -16,8 +16,8 @@ name-fld-list =
 "stmtprint,TSFinish,appaper,cecunit,fgpost,corsuply,fgitemsf,GP,oeprep,celayout,1099misc,RFQPrint,oecredit,maxbreak,aptax,rmemails,sspostfg,bolfmtx,schdcard,TSTIME,FGReOrder,ARMEMO,APCheckFile,OEPrompt,SSBOLSCAN,INVCOPYS,REMOVED,BORELDATE,OEINQ,ECBROWSE,VENDXFER,CUSTXFER,ORDERXFER,MISCJOBCL,RMUnderOver,CEPREPPRICE,RELTYPE,SSMoveFG,CEMISC,BolPostTime,CEDeliveryZone," +
 /* 130         131      132     133           134        135      136      137      138      139    140      141           142       143           144      145         146      147        148        149       150          151        152    153               154               155            156        157                   158         159            160         161*/
 "BOLFreight,CESAMPLE,SSRMISSUE,CorrTrim,CustShipToImp,OEScreen,fgoecost,runship,InvStatus,AGEDAYS,FGPostCmp,AckMaster,ChkFmtACH,OeDateChange,SSBOLEMAIL,FGRecptUnit,FGBrowseIA,AlliFlutes,SSBOLPRINT,POScreen,SSScanVendor,BOLFMTTran,POStatus,BOLMaster,CEMarkupMatrixLookup,overwriteJobPlan,capacityPage,OEPriceMatrixCheck,BOLPartial,OEAutoDateUpdate,FGUnderOver,OEPriceHold," + 
-/*  162       163        164        165        166        167     168       169         170        171     172          173       174            175               176*         177            178              179                     180                      181           182   183        184       185             186 */
-"CEUpdate,ValidShipTo,PriceHold,CreditHold,CustomerPO,UniquePO,ValidUoM,PriceGtCost,CustomerPN,CEOpRates,CERequestYield,CINVOICE,BOLPartialFlag,POLoadtag,FreightCalculation,OnHandInventory,MiscEstimateSource,SalesTaxRoundingMethod,SalesTaxCalcMethod,FGTagValidation,CEFormat,ItemHold,DuplicateItem,EstimateExists,DateRule".
+/*  162       163        164        165        166        167     168       169         170        171     172          173       174            175               176*         177            178              179                     180                      181           182   183        184       185             186          187*/
+"CEUpdate,ValidShipTo,PriceHold,CreditHold,CustomerPO,UniquePO,ValidUoM,PriceGtCost,CustomerPN,CEOpRates,CERequestYield,CINVOICE,BOLPartialFlag,POLoadtag,FreightCalculation,OnHandInventory,MiscEstimateSource,SalesTaxRoundingMethod,SalesTaxCalcMethod,FGTagValidation,CEFormat,ItemHold,DuplicateItem,EstimateExists,DateRule,Alliflutes1".
 
 DEFINE VARIABLE str-init AS CHARACTER EXTENT 200 NO-UNDO.
     
@@ -140,7 +140,7 @@ ASSIGN
  .
 ASSIGN
  str-init[51] = "None,CorrTrim,Alliance,HRMS,CorSuply,Corr-U-KraftII,GP," +
-                "Vendor,Kiwi,Smurfit,CorrChoice,Pratt,AlliFlutes,iPaper,KiwiT,Liberty"  
+                "Vendor,Kiwi,Smurfit,CorrChoice,Pratt,AlliFlutes,AlliFlutes1,iPaper,KiwiT,Liberty"  
  str-init[52] = "Percent,$/Pallet,$/MSF"
  str-init[53] = "AllItems,POOnly,None" 
  str-init[54] = "Sheet,Blank" 
@@ -238,7 +238,7 @@ ASSIGN str-init[125] = "Ship Only,Invoice Only,Bill and Ship,Transfer Only"
        str-init[144] = ",Added,Deleted,OverUnder"
        str-init[145] = "Order Item Counts,Pallet Counts"
        str-init[146] = ",TEAL"
-       str-init[147] = ",PremierPkg,McElroy,Bell,Capitol,Rudd,Trepaper,StClair"
+       str-init[147] = ",PremierPkg,McElroy,Bell,Capitol,Rudd,Trepaper,StClair,PS,GAP"
        str-init[148] = ",NoWarning,OverShipWarning,UnderShipWarning,OverUnderShipWarning"
        str-init[149] = ",Job-Item,Item-Job"
        str-init[150] = ",RMLot"
@@ -277,6 +277,7 @@ ASSIGN str-init[125] = "Ship Only,Invoice Only,Bill and Ship,Transfer Only"
        str-init[183] = "HOLD,INFO"
        str-init[184] = "HOLD,INFO"
        str-init[185] = "HOLD,INFO"
+       str-init[187] = ",PS,GAP"
        .
 	
 IF PROGRAM-NAME(1) MATCHES "*windows/l-syschr.w*" THEN DO:


### PR DESCRIPTION
Programs changed:
po/ftppo.p - added logic block for NK1 "AlliFlutes1"
sys/ref/sys-ctrl.i
- added list support for new NK1 AllFlutes1
- added "AlliFlutes1" to valid values for NK1 POEXPORT
- added "PS" and "GAP" to valid values for NK1 AlliFlutes
- added "PS" and "GAP" to valid values for NK1 Al;liFlutes1