### PR TITLE
92900 Ensure any new tables/fields are included in audit processing

### DIFF
--- a/Deployment/versionBuild/AutoCompile.bat
+++ b/Deployment/versionBuild/AutoCompile.bat
@@ -1,6 +1,14 @@
 @ECHO OFF
 
+IF EXIST c:\asigui\build\buildON.txt (
+    ECHO A build is already running
+    pause
+    GOTO :EXIT
+)
+TASKKILL /F /IM ASIbranchTest.exe > NUL
+
 :INITIALIZE
+SET buildDir=\asigui\build
 SET clogfile=c:\asigui\build\mergelog.txt
 SET cViewFile=c:\asigui\build\mergecomp.txt
 SET ghToken=5c5b4ee9facd6495549ae1a5e6c4184ec492807c
@@ -13,6 +21,11 @@ ECHO %date% %time% Merge/Compile Started > %cViewFile%
 ECHO ---------------------------------------------------- >> %cViewFile%
 ECHO %date% Merge/Compile >> %clogfile%
 ECHO ---------------------------------------------------- >> %clogFile%
+
+:: Update auditTbl/auditFld records
+C:
+CD %buildDir%
+CALL %DLCBIN%\prowin.exe -basekey "INI" -ininame versionBuild.ini -pf versionBuildBOTHDB.pf -p updateAuditTbl.p
 
 :GITHUB
 ECHO %time% Pulling latest merges from GitHub

--- a/Deployment/versionBuild/updateAuditTbl.p
+++ b/Deployment/versionBuild/updateAuditTbl.p
@@ -1,0 +1,49 @@
+DEF VAR cAuditExceptionList AS CHAR NO-UNDO.
+
+CONNECT -db TESTDEVELd -H EC2AMAZ-VE650C7 -S 2522 -ld ASI
+CONNECT -db TESTDEVELa -H EC2AMAZ-VE650C7 -S 2622 -ld AUDIT
+
+ASSIGN 
+    cAuditExceptionList = "dynParamValue,report,tag,Task,taskEmail,taskResult,user-print".
+
+FOR EACH _file NO-LOCK WHERE _file._Tbl-type EQ "T":
+    IF CAN-FIND(FIRST AuditTbl WHERE 
+        AuditTbl.AuditTable EQ _file._file-name) THEN NEXT.
+    IF CAN-FIND(FIRST _field OF _file WHERE 
+        ASI._field._field-name EQ "rec_key") EQ NO THEN NEXT.
+    IF CAN-FIND(FIRST _file-trig WHERE 
+        _file-trig._file-recid EQ recid(_file) AND 
+        _file-trig._event EQ "create") EQ NO THEN NEXT.
+    IF CAN-DO(cAuditExceptionList,_file._file-name) THEN NEXT.
+
+    IF NOT CAN-FIND(FIRST AuditTbl WHERE 
+        AuditTbl.AuditTable EQ _file._file-name) THEN DO:
+        CREATE AuditTbl.
+        ASSIGN
+            AuditTbl.AuditTable  = _file._file-name
+            AuditTbl.AuditCreate = NO
+            AuditTbl.AuditDelete = NO
+            AuditTbl.AuditUpdate = NO
+            AuditTbl.AuditStack  = NO
+            AuditTbl.expireDays = 0
+            AuditTbl.AuditCreateDefault = NO
+            AuditTbl.AuditDeleteDefault = NO
+            AuditTbl.AuditUpdateDefault = NO
+            AuditTbl.AuditStackDefault  = NO
+            AuditTbl.expireDaysDefault = 0
+            .
+    END.    
+    FOR EACH _field NO-LOCK OF _file:
+        IF NOT CAN-FIND(FIRST AuditFld WHERE 
+            AuditFld.AuditTable EQ _file._file-name AND 
+            auditFld.auditFld EQ _field._field-name) THEN DO:
+            CREATE AuditFld.
+            ASSIGN 
+                auditFld.auditTbl = _file._file-name
+                auditFld.auditFld = _field._field-name
+                auditFld.audit = NO 
+                auditFld.auditDefault = NO 
+                .
+        END.
+    END.        
+END.

--- a/Deployment/versionBuild/updateAuditTbl.p
+++ b/Deployment/versionBuild/updateAuditTbl.p
@@ -1,7 +1,7 @@
 DEF VAR cAuditExceptionList AS CHAR NO-UNDO.
 
-CONNECT -db TESTDEVELd -H EC2AMAZ-VE650C7 -S 2522 -ld ASI
-CONNECT -db TESTDEVELa -H EC2AMAZ-VE650C7 -S 2622 -ld AUDIT
+CONNECT -db TESTDEVELd -H EC2AMAZ-VE650C7 -S 2522 -ld ASI.
+CONNECT -db TESTDEVELa -H EC2AMAZ-VE650C7 -S 2622 -ld AUDIT.
 
 ASSIGN 
     cAuditExceptionList = "dynParamValue,report,tag,Task,taskEmail,taskResult,user-print".
@@ -10,7 +10,7 @@ FOR EACH _file NO-LOCK WHERE _file._Tbl-type EQ "T":
     IF CAN-FIND(FIRST AuditTbl WHERE 
         AuditTbl.AuditTable EQ _file._file-name) THEN NEXT.
     IF CAN-FIND(FIRST _field OF _file WHERE 
-        ASI._field._field-name EQ "rec_key") EQ NO THEN NEXT.
+        _field._field-name EQ "rec_key") EQ NO THEN NEXT.
     IF CAN-FIND(FIRST _file-trig WHERE 
         _file-trig._file-recid EQ recid(_file) AND 
         _file-trig._event EQ "create") EQ NO THEN NEXT.
@@ -36,11 +36,11 @@ FOR EACH _file NO-LOCK WHERE _file._Tbl-type EQ "T":
     FOR EACH _field NO-LOCK OF _file:
         IF NOT CAN-FIND(FIRST AuditFld WHERE 
             AuditFld.AuditTable EQ _file._file-name AND 
-            auditFld.auditFld EQ _field._field-name) THEN DO:
+            AuditFld.auditField EQ _field._field-name) THEN DO:
             CREATE AuditFld.
             ASSIGN 
-                auditFld.auditTbl = _file._file-name
-                auditFld.auditFld = _field._field-name
+                auditFld.auditTable = _file._file-name
+                auditFld.auditField = _field._field-name
                 auditFld.audit = NO 
                 auditFld.auditDefault = NO 
                 .


### PR DESCRIPTION
Files changed:
build/autoCompile.bat (daily build processor) - run updateAuditTbl.p (line 25)
(change at line 3 is related to ticket 92899)
build/updateAuditTbl.p (new file) - scans database to ensure all tables/fields are included in AuditTbl and AuditFld records