### PR TITLE
93144  Outlook use in Virtualized workstations having intermittent is…

### DIFF
--- a/Source/oerep/r-acknow.w
+++ b/Source/oerep/r-acknow.w
@@ -2438,7 +2438,7 @@ PROCEDURE GenerateEmail:
   IF NOT is-xprint-form THEN
     OS-COPY VALUE(list-name) VALUE(lv-pdf-file + ".txt").
   IF ls-to-list2 <> "" THEN ls-to-list = ls-to-list + "," + ls-to-list2.       
-  ASSIGN lv-mailto       = 'To:' + ls-to-list
+  ASSIGN lv-mailto       = IF ls-to-list NE "" THEN ('To:' + ls-to-list) ELSE ""
          lv-mailsubject  = vcSubject
          lv-mailbody     = vcMailBody
          lv-mailattach   =  IF is-xprint-form THEN lv-pdf-file + ".pdf" ELSE lv-pdf-file + ".txt" /*list-name*/.


### PR DESCRIPTION
…sues.

Program changed: oerep/r-acknow.w
Change causes Outlook to open with an empty "TO:" field if no acknowledgement contact is defined in customer or shipto record, and an acknowledgement is printed to email.  Prior to change, Outlook failed with Invalid Recipient message, which was suppressed and therefore not visible.