### PR TITLE
95500 Invalid check number values in ar-ledger

### DIFF
--- a/Deployment/BuildScript/ToCompile/asiUpdateEnv.w
+++ b/Deployment/BuildScript/ToCompile/asiUpdateEnv.w
@@ -2615,7 +2615,7 @@ PROCEDURE ipDataFix :
         RUN ipDataFix200202.
     IF fIntVer(cThisEntry) LT 20030300 THEN 
         RUN ipDataFix200303.
-    IF fIntVer(cThisEntry) LT 20030600 THEN 
+    IF fIntVer(cThisEntry) LE 20030600 THEN 
         RUN ipDataFix200306.
     IF fIntVer(cThisEntry) LT 99999999 THEN
         RUN ipDataFix999999.


### PR DESCRIPTION
File changed: asiUpdateENV.w
added procedure to correct old check number formats in ar-ledger.ref-num