### PR TITLE
96356 AR8 Report No Longer Shows Customer Numbers

### DIFF
--- a/Source/arrep/r-depsitA.w
+++ b/Source/arrep/r-depsitA.w
@@ -934,7 +934,7 @@ PROCEDURE get-detail-values :
    lv-name     = "".
 
   IF ip-jrnl EQ "CASHR" THEN DO:
-     lv-check-no = INT64(SUBSTR(ip-dscr,INDEX(ip-dscr," Inv# ") - 10,12)) NO-ERROR.
+     lv-check-no = INT64(SUBSTR(ip-dscr,INDEX(ip-dscr," Inv# ") - 12,12)) NO-ERROR.
      IF ERROR-STATUS:ERROR THEN lv-check-no = 0.
 
      lv-inv-no = INT(SUBSTR(ip-dscr,INDEX(ip-dscr," Inv# ") + 6,10)) NO-ERROR.

--- a/Source/arrep/r-depsitN.w
+++ b/Source/arrep/r-depsitN.w
@@ -1253,7 +1253,7 @@ PROCEDURE get-detail-values :
    lv-name     = "".
 
   IF ip-jrnl EQ "CASHR" THEN DO:
-     lv-check-no = INT64(SUBSTR(ip-dscr,INDEX(ip-dscr," Inv# ") - 10,12)) NO-ERROR.
+     lv-check-no = INT64(SUBSTR(ip-dscr,INDEX(ip-dscr," Inv# ") - 12,12)) NO-ERROR.
      IF ERROR-STATUS:ERROR THEN lv-check-no = 0.
 
      lv-inv-no = INT(SUBSTR(ip-dscr,INDEX(ip-dscr," Inv# ") + 6,10)) NO-ERROR.


### PR DESCRIPTION
Programs changed:
arrep/r-depsitN.w
arrep/r-depsitA.w
corrected substring error prevent identification of check number, and therefore cust name