### PR TITLE
96105 O-B-1 Invoice Printer Icon

### DIFF
--- a/Source/oerep/r-invprtProc.i
+++ b/Source/oerep/r-invprtProc.i
@@ -770,13 +770,13 @@ lInRange = TRUE.
           WHERE b-{&head}1.{&rno} EQ ipbf-inv-head.{&rno}
           :
                
-           &IF b-{&head}1.bol-no NE 0 &THEN 
+           IF b-{&head}1.bol-no NE 0 THEN DO: 
                 FOR EACH oe-bolh NO-LOCK 
                     WHERE oe-bolh.b-no EQ b-{&head}1.bol-no:
                                 
                   {&bol-check-range}
                 END.
-           &ENDIF.
+           END.
            
        END. /* each line */
   &ENDIF.   


### PR DESCRIPTION
Program changed: oerep/r-invprtProc.i
Double &IF caused OE print to fail