### PR TITLE
96611 Print Loadtag from O-U-1 crash

### DIFF
--- a/Source/oerep/LoadtagProcs.p
+++ b/Source/oerep/LoadtagProcs.p
@@ -27,7 +27,7 @@ DEFINE VARIABLE gcLabelMatrixLoadTagOutputPath         AS CHARACTER NO-UNDO.
 DEFINE VARIABLE iTagCounter  AS INTEGER NO-UNDO.
 DEFINE VARIABLE iPalletCount AS INTEGER NO-UNDO.
 
-{oerep/ttLoadTag.i SHARED}
+{oerep/ttLoadTag.i NEW SHARED}
 {fg/fullset.i NEW}
 {oerep/r-loadtg.i }
 {custom/xprint.i}

--- a/Source/oerep/ttLoadtag.i
+++ b/Source/oerep/ttLoadtag.i
@@ -1,4 +1,4 @@
-DEFINE {1} TEMP-TABLE ttLoadTag
+DEFINE {1} {2} TEMP-TABLE ttLoadTag
     FIELD   company         AS      CHARACTER     
     FIELD   warehouseID     AS      CHARACTER 
     FIELD   locationID      AS      CHARACTER  


### PR DESCRIPTION
Programs changed:
oerep/LoadTagProcs.p - added "NEW" parm to tt definition
oerep/ttLoadtag.i - added support for multiple parms (NEW SHARED) in tt definition