### PR TITLE
96518 - Black browse screen

### DIFF
--- a/Deployment/BuildScript/ToCompile/asiLogin.w
+++ b/Deployment/BuildScript/ToCompile/asiLogin.w
@@ -1012,7 +1012,8 @@ PROCEDURE ipClickOk :
                 PUT-KEY-VALUE SECTION "Colors" KEY "Color" + STRING(iCtr - 1) VALUE ENTRY(iCtr,cOldColors,"|").
             END.
         END.
-
+        PUT-KEY-VALUE COLOR ALL.
+        PUT-KEY-VALUE FONT ALL.
         /* Set current dir */
         RUN ipSetCurrentDir (cMapDir + "\" + cEnvDir + "\" + cbEnvironment). 
         


### PR DESCRIPTION
File changed: asiLogin.w
added PUT-KEY-VALUE statements with COLOR and FONT options
This is required to load the just-created elements in the .ini file into the current environment
Without this, running an old version, immediately followed by running a new version, keeps the old values from the ini file in the new environment.
Essentially, these statements "refresh" the font and color tables