### PR TITLE
97035 Error at Soule - create BOL

### DIFF
--- a/Deployment/BuildScript/ToCompile/asiUpdateEnv.w
+++ b/Deployment/BuildScript/ToCompile/asiUpdateEnv.w
@@ -3677,8 +3677,8 @@ PROCEDURE ipExpandFiles :
     OS-COPY VALUE(cTgtEnv + "\Programs\DataDigger\Cache\*.*") VALUE(cTgtEnv + "\CustFiles\DDBackups\Cache").
     
     /* Delete old overrides */
-    OS-DELETE VALUE(cUpdProgramDir + "\Override") RECURSIVE.
-    OS-CREATE-DIR VALUE(cUpdProgramDir + "\Override").
+    OS-DELETE VALUE(cTgtEnv + "\Override") RECURSIVE.
+    OS-CREATE-DIR VALUE(cTgtEnv + "\Override").
     
     /* Unzip/move breaks for any number of security reasons; just copy  */
     RUN ipStatus ("  Copying system files from ").


### PR DESCRIPTION
Fixed issue with updating /Override folder
was deleting the to-be-applied folder instead of the /Environment/Override folder