### PR TITLE
97627 custom/rec_key.i creates non-unique records when called from up…

### DIFF
--- a/Source/custom/rec_key.i
+++ b/Source/custom/rec_key.i
@@ -1,20 +1,6 @@
-IF fSuperRunning("session.") THEN DO:
-    {1}.rec_key = DYNAMIC-FUNCTION("sfGetNextRecKey").    
-/*    CREATE rec_key.                     */
-/*    ASSIGN                              */
-/*        rec_key.rec_key    = {1}.rec_key*/
-/*        rec_key.table_name = "{1}"      */
-/*        .                               */
-END. /* if super running */ 
-ELSE DO:
-    {1}.rec_key = STRING(YEAR(TODAY),"9999")
-                + STRING(MONTH(TODAY),"99")
-                + STRING(DAY(TODAY),"99")
-                + STRING(TIME,"99999")
-                + ".NoSuper"
-                .
-    /* 97591 GLConvertGLTrans */
-    /* RUN custom/RecKeyLog.p ("{1}"). */
-END. /* else */
-/* Resolves hanging EXCLUSIVE lock issue whenever a record is created */
-/* FIND CURRENT rec_key NO-LOCK NO-ERROR. */
+ASSIGN 
+    {1}.rec_key =   STRING(YEAR(TODAY),"9999") + 
+                    STRING(MONTH(TODAY),"99") + 
+                    STRING(DAY(TODAY),"99") + 
+                    STRING(TIME,"99999") + 
+                    STRING(NEXT-VALUE(rec_key_seq,ASI),"99999999").


### PR DESCRIPTION
…grade program

Program changed: custom/rec_key.i
Removed the ".NoSuper" string that prevented unique reckeys when bulk loading records
Noticed that with this change, the DYN-FUNCTION call did exactly the same as the manual rec_key ASSIGNment
Removed the DYN-FUNCTION since the direct ASSIGNMENT would ALWAYS be faster