### PR TITLE
97450 PF3 VCM Export not Working

### DIFF
--- a/Source/est/rd-qhexp.w
+++ b/Source/est/rd-qhexp.w
@@ -1170,7 +1170,7 @@ DEFINE VARIABLE list-name AS cha NO-UNDO.
 DEFINE VARIABLE lv-pdf-file AS cha NO-UNDO.
 DEFINE VARIABLE iQty AS INTEGER NO-UNDO .
 DEFINE VARIABLE dPrice AS DECIMAL NO-UNDO .
-DEFINE VARIABLE dProfit AS DECIMAL FORMAT "->>,>>9.99%" NO-UNDO .
+DEFINE VARIABLE dProfit AS DECIMAL FORMAT "->,>>>,>>9.99%" NO-UNDO .
 DEFINE VARIABLE cUom AS CHARACTER NO-UNDO .
 DEFINE VARIABLE cFileName LIKE fi_file NO-UNDO . 
 DEFINE VARIABLE cItemCategory AS CHARACTER  NO-UNDO .
@@ -1237,6 +1237,8 @@ FOR EACH quotehd
           dPrice = DECIMAL(quoteqty.price)
           dProfit = DECIMAL(quoteqty.profit) 
           cUom   = quoteqty.uom .
+     IF dProfit EQ ? THEN ASSIGN 
+        dProfit = 9999999.99.
     
 
     FOR EACH ttRptSelected:
@@ -1253,7 +1255,7 @@ FOR EACH quotehd
             WHEN "price" THEN                                                                
                 v-excel-detail-lines = v-excel-detail-lines + appendXLLine(STRING(dPrice)). 
             WHEN "profit" THEN                                                                
-                v-excel-detail-lines = v-excel-detail-lines + appendXLLine(STRING(dProfit, "->>,>>9.99")).
+                v-excel-detail-lines = v-excel-detail-lines + appendXLLine(STRING(dProfit)).
             WHEN "price-uom" THEN                                                                
                 v-excel-detail-lines = v-excel-detail-lines + appendXLLine(cUom). 
             WHEN "shipto" THEN                                                                

--- a/Source/est/rd-qhexp.w
+++ b/Source/est/rd-qhexp.w
@@ -78,7 +78,7 @@ ASSIGN cTextListToSelect = "Part #,Customer,Quote#,Quantity,Price,Profit %,Price
 {sys/inc/ttRptSel.i}
 ASSIGN cTextListToDefault  = "Part #,Customer,Quote#,Quantity,Price,Profit %,Price UOM,ShipTo,SoldTo,Quote Date,Delivery Date,Expiration Date," +
                              "Estimate #,Contact,Sales Group,Terms Code,Carrier,Zone,FG Item #,Item Description," +
-                             "Item Description 2,Est Style,Dimensions,Board,Color,FG Category, EST Category" .
+                             "Item Description 2,Est Style,Dimensions,Board,Color,FG Category,EST Category" .
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
 

--- a/Source/po/VendCostExp.w
+++ b/Source/po/VendCostExp.w
@@ -1185,101 +1185,101 @@ FOR EACH vendItemCost WHERE vendItemCost.company = cocode
                CASE ttRptSelected.FieldList:   
                        WHEN "levelQuantity1"  THEN do:
                          IF i EQ 1 THEN do:
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.quantityBase,">>>>>>>9.9<<")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costPerUOM,">>>>9.9999")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costSetup,"->>>>9.99")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costDeviation,"->>>>>>>9.99")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.leadTimeDays,">>>>>>9")).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.quantityBase)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costPerUOM)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costSetup)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costDeviation)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.leadTimeDays)).
                            lCheckData = YES.
                          END.
                        END.
                        WHEN "levelQuantity2" THEN DO:
                          IF i EQ 2 THEN do:
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.quantityBase,">>>>>>>9.9<<")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costPerUOM,">>>>9.9999")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costSetup,"->>>>9.99")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costDeviation,"->>>>>>>9.99")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.leadTimeDays,">>>>>>9")).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.quantityBase)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costPerUOM)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costSetup)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costDeviation)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.leadTimeDays)).
                            lCheckData = YES.
                          END.
                        END.
                        WHEN "levelQuantity3"  THEN DO:
                          IF i EQ 3 THEN do:
-                          v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.quantityBase,">>>>>>>9.9<<")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costPerUOM,">>>>9.9999")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costSetup,"->>>>9.99")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costDeviation,"->>>>>>>9.99")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.leadTimeDays,">>>>>>9")).
+                          v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.quantityBase)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costPerUOM)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costSetup)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costDeviation)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.leadTimeDays)).
                            lCheckData = YES.
                          END.
                        END.
                        WHEN "levelQuantity4" THEN DO:
                          IF i EQ 4 THEN do:
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.quantityBase,">>>>>>>9.9<<")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costPerUOM,">>>>9.9999")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costSetup,"->>>>9.99")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costDeviation,"->>>>>>>9.99")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.leadTimeDays,">>>>>>9")).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.quantityBase)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costPerUOM)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costSetup)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costDeviation)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.leadTimeDays)).
                            lCheckData = YES.
                          END.
                        END.
                        WHEN "levelQuantity5"  THEN DO:
                          IF i EQ 5 THEN do:
-                          v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.quantityBase,">>>>>>>9.9<<")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costPerUOM,">>>>9.9999")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costSetup,"->>>>9.99")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costDeviation,"->>>>>>>9.99")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.leadTimeDays,">>>>>>9")).
+                          v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.quantityBase)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costPerUOM)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costSetup)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costDeviation)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.leadTimeDays)).
                            lCheckData = YES.
                          END.
                        END.
                        WHEN "levelQuantity6" THEN do:
                          IF i EQ 6 THEN do:
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.quantityBase,">>>>>>>9.9<<")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costPerUOM,">>>>9.9999")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costSetup,"->>>>9.99")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costDeviation,"->>>>>>>9.99")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.leadTimeDays,">>>>>>9")).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.quantityBase)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costPerUOM)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costSetup)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costDeviation)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.leadTimeDays)).
                            lCheckData = YES.
                          END.
                        END.
                        WHEN "levelQuantity7" THEN DO:
                          IF i EQ 7 THEN do:
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.quantityBase,">>>>>>>9.9<<")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costPerUOM,">>>>9.9999")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costSetup,"->>>>9.99")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costDeviation,"->>>>>>>9.99")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.leadTimeDays,">>>>>>9")).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.quantityBase)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costPerUOM)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costSetup)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costDeviation)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.leadTimeDays)).
                            lCheckData = YES.
                          END.
                        END.
                        WHEN "levelQuantity8" THEN DO:
                          IF i EQ 8 THEN do:
-                          v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.quantityBase,">>>>>>>9.9<<")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costPerUOM,">>>>9.9999")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costSetup,"->>>>9.99")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costDeviation,"->>>>>>>9.99")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.leadTimeDays,">>>>>>9")).
+                          v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.quantityBase)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costPerUOM)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costSetup)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costDeviation)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.leadTimeDays)).
                            lCheckData = YES.
                          END.
                        END.
                        WHEN "levelQuantity9"  THEN DO:
                          IF i EQ 9 THEN do:
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.quantityBase,">>>>>>>9.9<<")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costPerUOM,">>>>9.9999")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costSetup,"->>>>9.99")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costDeviation,"->>>>>>>9.99")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.leadTimeDays,">>>>>>9")).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.quantityBase)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costPerUOM)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costSetup)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costDeviation)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.leadTimeDays)).
                            lCheckData = YES.
                          END.
                        END.
                        WHEN "levelQuantity10" THEN DO:
                          IF i EQ 10 THEN do:
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.quantityBase,">>>>>>>9.9<<")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costPerUOM,">>>>9.9999")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costSetup,"->>>>9.99")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costDeviation,"->>>>>>>9.99")).
-                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.leadTimeDays,">>>>>>9")).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.quantityBase)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costPerUOM)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costSetup)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.costDeviation)).
+                           v-excel-detail-lines = v-excel-detail-lines + appendXLLine(string(vendItemCostLevel.leadTimeDays)).
                            lCheckData = YES.
                          END.
                        END.


### PR DESCRIPTION
programs changed:
est/rd-qhexp.w - assigned zero-cost profit calc to be max values, removed formatting from numeric string exports
po/VendCostExp.w - romoved formatting from numeric string exports