### PR TITLE
#97118 Remove session.p instantiations from Inbound API programs

### DIFF
--- a/Source/api/inbound/ConsumeInventoryViaBOL.p
+++ b/Source/api/inbound/ConsumeInventoryViaBOL.p
@@ -50,12 +50,7 @@
     DEFINE VARIABLE iTopLevelParent    AS INTEGER   NO-UNDO INITIAL 0.
     DEFINE VARIABLE cValidFreightTerms AS CHARACTER NO-UNDO INITIAL "P,B,C,T".
 
-    {methods/defines/globdefs.i}
-    {methods/defines/hndldefs.i}
-    
-    DEFINE VARIABLE hdSession AS HANDLE NO-UNDO.
-    DEFINE VARIABLE hdTags    AS HANDLE NO-UNDO.
-        
+    {methods/defines/globdefs.i}        
     {sys/inc/var.i NEW SHARED}
     {sys/inc/varasgn.i}  
         

--- a/Source/api/inbound/CreateBillOfLading.p
+++ b/Source/api/inbound/CreateBillOfLading.p
@@ -22,22 +22,10 @@ DEFINE VARIABLE lValidReleaseID  AS LOGICAL   NO-UNDO.
 DEFINE VARIABLE lValidCompany    AS LOGICAL   NO-UNDO.
   
 /* This will eventually move to setsession approach */
-&SCOPED-DEFINE NEW NEW
 {methods/defines/globdefs.i}
-{methods/defines/hndldefs.i}
-  
-DEFINE VARIABLE hSession AS HANDLE NO-UNDO.
-DEFINE VARIABLE hTags    AS HANDLE NO-UNDO.
   
 g_company=ipcCompany.
-  
-RUN nosweat/persist.p  PERSISTENT SET Persistent-Handle.
-RUN lstlogic/persist.p PERSISTENT SET ListLogic-Handle.
-  
-RUN system/session.p  PERSISTENT SET hSession.
-SESSION:ADD-SUPER-PROCEDURE (hSession).
-RUN system/TagProcs.p PERSISTENT SET hTags.
-SESSION:ADD-SUPER-PROCEDURE (hTags).
+
 {sys/inc/var.i "new shared"}
 
 RUN oe/OrderProcs.p PERSISTENT SET hdOrderProcs.

--- a/Source/api/inbound/CreateInventoryReceipt.p
+++ b/Source/api/inbound/CreateInventoryReceipt.p
@@ -35,22 +35,10 @@ DEFINE OUTPUT       PARAMETER opcMessage                 AS CHARACTER NO-UNDO.
 {api\inbound\ttRctd.i}
 
 /* This will eventually move to setsession - START >>>*/
-&SCOPED-DEFINE NEW NEW
 {methods/defines/globdefs.i}
-{methods/defines/hndldefs.i}
-
-DEFINE VARIABLE hdSession AS HANDLE NO-UNDO.
-DEFINE VARIABLE hdTags    AS HANDLE NO-UNDO.
 
 g_company=ipcCompany.
 
-RUN nosweat/persist.p  PERSISTENT SET Persistent-Handle.
-RUN lstlogic/persist.p PERSISTENT SET ListLogic-Handle.
-
-RUN system/session.p  PERSISTENT SET hdSession.
-SESSION:ADD-SUPER-PROCEDURE (hdSession).
-RUN system/TagProcs.p PERSISTENT SET hdTags.
-SESSION:ADD-SUPER-PROCEDURE (hdTags).
 {sys/inc/var.i "new shared"}
 /* END <<<*/
 
@@ -1036,12 +1024,4 @@ PROCEDURE pGetQtyFrm PRIVATE:
 END PROCEDURE.
 
 DELETE PROCEDURE hdInventoryReceipt.
-DELETE PROCEDURE hdSession.
-DELETE PROCEDURE hdTags.
 DELETE PROCEDURE hdInventoryProcs.
-
-
-    
-    
-
-

--- a/Source/api/inbound/CreateInventoryTransfer.p
+++ b/Source/api/inbound/CreateInventoryTransfer.p
@@ -27,22 +27,10 @@ DEFINE OUTPUT PARAMETER oplSuccess              AS LOGICAL    NO-UNDO.
 DEFINE OUTPUT PARAMETER opcMessage              AS CHARACTER  NO-UNDO.
 
 /* This will eventually move to setsession approach */
-&SCOPED-DEFINE NEW NEW
 {methods/defines/globdefs.i}
-{methods/defines/hndldefs.i}
-
-DEFINE VARIABLE hSession AS HANDLE NO-UNDO.
-DEFINE VARIABLE hTags    AS HANDLE NO-UNDO.
 
 g_company=ipcCompany.
 
-RUN nosweat/persist.p  PERSISTENT SET Persistent-Handle.
-RUN lstlogic/persist.p PERSISTENT SET ListLogic-Handle.
-
-RUN system/session.p  PERSISTENT SET hSession.
-SESSION:ADD-SUPER-PROCEDURE (hSession).
-RUN system/TagProcs.p PERSISTENT SET hTags.
-SESSION:ADD-SUPER-PROCEDURE (hTags).
 {sys/inc/var.i "new shared"}
 
 DEFINE VARIABLE hdInventoryProcs AS HANDLE    NO-UNDO.

--- a/Source/api/inbound/CreateTagForPO.p
+++ b/Source/api/inbound/CreateTagForPO.p
@@ -61,19 +61,7 @@ DEFINE VARIABLE lPromptForClose  AS LOGICAL   NO-UNDO.
 {api\inbound\ttRctd.i} 
                          
 /* This will eventually move to setsession - START >>>*/
-&SCOPED-DEFINE NEW NEW
 {methods/defines/globdefs.i}
-{methods/defines/hndldefs.i}
-  
-DEFINE VARIABLE hdSession AS HANDLE NO-UNDO.
-DEFINE VARIABLE hdTags    AS HANDLE NO-UNDO.
- 
-RUN nosweat/persist.p  PERSISTENT SET Persistent-Handle.
-RUN lstlogic/persist.p PERSISTENT SET ListLogic-Handle.
-RUN system/session.p  PERSISTENT SET hdSession.
-SESSION:ADD-SUPER-PROCEDURE (hdSession).
-RUN system/TagProcs.p PERSISTENT SET hdTags.
-SESSION:ADD-SUPER-PROCEDURE (hdTags).
 {sys/inc/var.i "new shared"}
 ASSIGN
     g_company = ipcCompany
@@ -843,11 +831,4 @@ PROCEDURE pRMReceiptCreation PRIVATE:
 END PROCEDURE.
 
 DELETE PROCEDURE hdReceipt.
-DELETE PROCEDURE hdSession.
-DELETE PROCEDURE hdTags.
 DELETE PROCEDURE hdInventoryProcs.
-
-    
-    
-
-

--- a/Source/api/inbound/CreateVendorInvoice.p
+++ b/Source/api/inbound/CreateVendorInvoice.p
@@ -36,22 +36,10 @@ DEFINE OUTPUT PARAMETER opcMessage                                  AS CHARACTER
 {api/inbound/ttRctd.i}
 
 /* This will eventually move to setsession - START >>>*/
-&SCOPED-DEFINE NEW NEW
 {methods/defines/globdefs.i}
-{methods/defines/hndldefs.i}
-
-DEFINE VARIABLE hdSession AS HANDLE NO-UNDO.
-DEFINE VARIABLE hdTags    AS HANDLE NO-UNDO.
 
 g_company=ipcCompany.
 
-RUN nosweat/persist.p  PERSISTENT SET Persistent-Handle.
-RUN lstlogic/persist.p PERSISTENT SET ListLogic-Handle.
-
-RUN system/session.p  PERSISTENT SET hdSession.
-SESSION:ADD-SUPER-PROCEDURE (hdSession).
-RUN system/TagProcs.p PERSISTENT SET hdTags.
-SESSION:ADD-SUPER-PROCEDURE (hdTags).
 {sys/inc/var.i "new shared"}
 /* END <<<*/
 

--- a/Source/api/inbound/SplitTag.p
+++ b/Source/api/inbound/SplitTag.p
@@ -35,22 +35,8 @@ DEFINE VARIABLE cStockIDAlias            AS CHARACTER NO-UNDO.
 DEFINE VARIABLE cNewInventoryStockID     AS CHARACTER NO-UNDO.  
 
 /* This will eventually move to setsession - START >>>*/
-&SCOPED-DEFINE NEW NEW
 {methods/defines/globdefs.i}
-{methods/defines/hndldefs.i}
-
-DEFINE VARIABLE hdSession AS HANDLE NO-UNDO.
-DEFINE VARIABLE hdTags    AS HANDLE NO-UNDO.
-
 g_company=ipcCompany.
-
-RUN nosweat/persist.p  PERSISTENT SET Persistent-Handle.
-RUN lstlogic/persist.p PERSISTENT SET ListLogic-Handle.
-
-RUN system/session.p  PERSISTENT SET hdSession.
-SESSION:ADD-SUPER-PROCEDURE (hdSession).
-RUN system/TagProcs.p PERSISTENT SET hdTags.
-SESSION:ADD-SUPER-PROCEDURE (hdTags).
 {sys/inc/var.i "new shared"}
 /* END <<<*/
 

--- a/Source/api/inbound/handlers/ConsumeInventoryViaBOLRequestHandler.p
+++ b/Source/api/inbound/handlers/ConsumeInventoryViaBOLRequestHandler.p
@@ -29,20 +29,7 @@
        ( refer methods/triggers/create.i ) */
     
     /* This will eventually move to setsession approach */
-    &SCOPED-DEFINE NEW NEW
     {methods/defines/globdefs.i}
-    {methods/defines/hndldefs.i}
-    
-    DEFINE VARIABLE hdSession AS HANDLE NO-UNDO.
-    DEFINE VARIABLE hdTags    AS HANDLE NO-UNDO.
-        
-    RUN nosweat/persist.p  PERSISTENT SET Persistent-Handle.
-    RUN lstlogic/persist.p PERSISTENT SET ListLogic-Handle.
-    
-    RUN system/session.p  PERSISTENT SET hdSession.
-    SESSION:ADD-SUPER-PROCEDURE (hdSession).
-    RUN system/TagProcs.p PERSISTENT SET hdTags.
-    SESSION:ADD-SUPER-PROCEDURE (hdTags).
     {sys/inc/var.i "new shared"}
     {sys/inc/varasgn.i}    
  
@@ -66,9 +53,3 @@
         oplcResponseData = '~{"response_code":200,"response_message":"Inventory Consume is successful"}'
         opcMessage = "Success"
         .
-    
-    SESSION:REMOVE-SUPER-PROCEDURE (hdSession).
-    DELETE PROCEDURE hdSession.
-    SESSION:REMOVE-SUPER-PROCEDURE (hdTags).
-    DELETE PROCEDURE hdTags.
-    

--- a/Source/api/inbound/handlers/CreateInventoryAdjustmentRequestHandler.p
+++ b/Source/api/inbound/handlers/CreateInventoryAdjustmentRequestHandler.p
@@ -51,18 +51,7 @@
        ( refer methods/triggers/create.i ) */
 
     /* This will eventually move to setsession approach */
-    &SCOPED-DEFINE NEW NEW
     {methods/defines/globdefs.i}
-    {methods/defines/hndldefs.i}
-
-    DEFINE VARIABLE hdSession AS HANDLE NO-UNDO.
-
-    RUN nosweat/persist.p  PERSISTENT SET Persistent-Handle.
-    RUN lstlogic/persist.p PERSISTENT SET ListLogic-Handle.
-
-    RUN system/session.p  PERSISTENT SET hdSession.
-    SESSION:ADD-SUPER-PROCEDURE (hdSession).
-
     {sys/inc/var.i "NEW SHARED"}
     {sys/inc/varasgn.i}
 
@@ -111,9 +100,6 @@
         
     THIS-PROCEDURE:REMOVE-SUPER-PROCEDURE(hdJSONProcs).
     DELETE PROCEDURE hdJSONProcs.
-
-    SESSION:REMOVE-SUPER-PROCEDURE (hdSession).
-    DELETE PROCEDURE hdSession.
 
 /* ********************  Preprocessor Definitions  ******************** */
 

--- a/Source/api/inbound/handlers/CreateInventoryCountRequestHandler.p
+++ b/Source/api/inbound/handlers/CreateInventoryCountRequestHandler.p
@@ -56,22 +56,7 @@
        ( refer methods/triggers/create.i ) */
 
     /* This will eventually move to setsession approach */
-    &SCOPED-DEFINE NEW NEW
     {methods/defines/globdefs.i}
-    {methods/defines/hndldefs.i}
-
-    DEFINE VARIABLE hdSession AS HANDLE NO-UNDO.
-    DEFINE VARIABLE hdTags    AS HANDLE NO-UNDO.
-
-    RUN nosweat/persist.p  PERSISTENT SET Persistent-Handle.
-    RUN lstlogic/persist.p PERSISTENT SET ListLogic-Handle.
-
-    RUN system/session.p  PERSISTENT SET hdSession.
-    SESSION:ADD-SUPER-PROCEDURE (hdSession).
-
-    RUN system/TagProcs.p PERSISTENT SET hdTags.
-    SESSION:ADD-SUPER-PROCEDURE (hdTags).
-
     {sys/inc/var.i "NEW SHARED"}
     {sys/inc/varasgn.i}
 
@@ -127,12 +112,6 @@
 
     THIS-PROCEDURE:REMOVE-SUPER-PROCEDURE(hdCommonProcs).
     DELETE PROCEDURE hdCommonProcs.
-
-    SESSION:REMOVE-SUPER-PROCEDURE (hdSession).
-    DELETE PROCEDURE hdSession.
-
-    SESSION:REMOVE-SUPER-PROCEDURE (hdTags).
-    DELETE PROCEDURE hdTags.
 
     PROCEDURE pPrepareInputs PRIVATE:
     /*------------------------------------------------------------------------------

--- a/Source/api/inbound/handlers/CreateTagForPORequestHandler.p
+++ b/Source/api/inbound/handlers/CreateTagForPORequestHandler.p
@@ -46,10 +46,6 @@ DEFINE VARIABLE iTagCopies          AS INTEGER    NO-UNDO.
    create trigger, only if session.p is running persistently, else will be populated with empty value.
    ( refer methods/triggers/create.i ) */
 
-DEFINE VARIABLE hdSession AS HANDLE NO-UNDO.
-RUN system/session.p PERSISTENT SET hdSession.
-SESSION:ADD-SUPER-PROCEDURE (hdSession).
-
 RUN api/JSONProcs.p PERSISTENT SET hdJSONProcs. 
 THIS-PROCEDURE:ADD-SUPER-PROCEDURE(hdJSONProcs). 
 
@@ -261,6 +257,3 @@ PROCEDURE pProcessInputs:
         END.
     END.
 END PROCEDURE.            
-
-SESSION:REMOVE-SUPER-PROCEDURE (hdSession).
-DELETE PROCEDURE hdSession.

--- a/Source/api/inbound/handlers/GetInventoryRequestHandler.p
+++ b/Source/api/inbound/handlers/GetInventoryRequestHandler.p
@@ -42,9 +42,6 @@ DEFINE VARIABLE cCustNo                 AS CHARACTER NO-UNDO.
 /* The below code is added as APIInboundEvent.rec_key will be populated in the APIInboundEvent's
    create trigger, only if session.p is running persistently, else will be populated with empty value.
    ( refer methods/triggers/create.i ) */
-DEFINE VARIABLE hdSession AS HANDLE NO-UNDO.
-RUN system/session.p PERSISTENT SET hdSession.
-SESSION:ADD-SUPER-PROCEDURE (hdSession).
 
 RUN api/JSONProcs.p PERSISTENT SET hdJSONProcs.
 THIS-PROCEDURE:ADD-SUPER-PROCEDURE(hdJSONProcs). 
@@ -209,7 +206,4 @@ PROCEDURE pProcessInputs:
         oplcConcatResponseData = TRIM(oplcConcatResponseData,",") 
         .
 END PROCEDURE. 
-
-SESSION:REMOVE-SUPER-PROCEDURE (hdSession).
-DELETE PROCEDURE hdSession.
   

--- a/Source/api/inbound/handlers/UpdateItemRequestHandler.p
+++ b/Source/api/inbound/handlers/UpdateItemRequestHandler.p
@@ -38,20 +38,6 @@ DEFINE VARIABLE iResponseCode AS INTEGER NO-UNDO.
 /* This will eventually move to setsession approach */
 &SCOPED-DEFINE NEW NEW
 {methods/defines/globdefs.i}
-{methods/defines/hndldefs.i}
-
-DEFINE VARIABLE hdSession AS HANDLE NO-UNDO.
-DEFINE VARIABLE hdTags    AS HANDLE NO-UNDO.
-
-RUN nosweat/persist.p  PERSISTENT SET Persistent-Handle.
-RUN lstlogic/persist.p PERSISTENT SET ListLogic-Handle.
-
-RUN system/session.p  PERSISTENT SET hdSession.
-SESSION:ADD-SUPER-PROCEDURE (hdSession).
-
-RUN system/TagProcs.p PERSISTENT SET hdTags.
-SESSION:ADD-SUPER-PROCEDURE (hdTags).
-
 {sys/inc/var.i "NEW SHARED"}
 {sys/inc/varasgn.i}
 
@@ -100,12 +86,6 @@ RUN JSON_GetResponseData (
 
 THIS-PROCEDURE:REMOVE-SUPER-PROCEDURE(hdJSONProcs).
 DELETE PROCEDURE hdJSONProcs.
-
-SESSION:REMOVE-SUPER-PROCEDURE (hdSession).
-DELETE PROCEDURE hdSession.
-
-SESSION:REMOVE-SUPER-PROCEDURE (hdTags).
-DELETE PROCEDURE hdTags.
 
 PROCEDURE pPrepareInputs PRIVATE:
 /*------------------------------------------------------------------------------

--- a/Source/api/inbound/handlers/UpdateTagStatusRequestHandler.p
+++ b/Source/api/inbound/handlers/UpdateTagStatusRequestHandler.p
@@ -46,10 +46,6 @@ DEFINE VARIABLE cStatusID           AS CHARACTER  NO-UNDO.
    create trigger, only if session.p is running persistently, else will be populated with empty value.
    ( refer methods/triggers/create.i ) */
 
-DEFINE VARIABLE hdSession AS HANDLE NO-UNDO.
-RUN system/session.p PERSISTENT SET hdSession.
-SESSION:ADD-SUPER-PROCEDURE (hdSession).
-
 RUN api/JSONProcs.p PERSISTENT SET hdJSONProcs. 
 THIS-PROCEDURE:ADD-SUPER-PROCEDURE(hdJSONProcs). 
 
@@ -254,6 +250,3 @@ PROCEDURE pProcessInputs:
         END.
     END.
 END PROCEDURE.            
-
-SESSION:REMOVE-SUPER-PROCEDURE (hdSession).
-DELETE PROCEDURE hdSession.


### PR DESCRIPTION
Files:
inbound/handlers/ConsumeInventoryViaBOL.p
inbound/handlers/CreateInventoryAdjustsment.p
inbound/handlers/CreateInventoryCountRequestHandler.p
inbound/handlers/CreateTagForPORequestHandler.p
inbound/handlers/GetInventoryRequestHandler.p
inbound/handlers/UpdateItemRequestHandler.p
inbound/handlers/UpdateTagRequestHandler.p
inbound/ConsumeInventoryViaBOL.p
inbound/CreateBillOfLading.p
inbound/CreateInventoryReceipt.p
inbound/CreateInventoryTransfer.p
inbound/CreateTagForPO.p
inbound/CreateVendorInvoice.p
inbound/SplitTag.p