### PR TITLE
98086 - Close Period Report - Run during upgrade

### DIFF
--- a/Deployment/BuildScript/ToCompile/asiUpdateEnv.w
+++ b/Deployment/BuildScript/ToCompile/asiUpdateEnv.w
@@ -1984,6 +1984,38 @@ END PROCEDURE.
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
 
+
+
+&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipConvertGLTrans C-Win
+PROCEDURE ipConvertGLTrans:
+    /*------------------------------------------------------------------------------
+     Purpose:
+     Notes:
+    ------------------------------------------------------------------------------*/
+    DEF VAR cOrigPropath AS CHAR NO-UNDO.
+    DEF VAR cNewPropath AS CHAR NO-UNDO.
+
+    ASSIGN
+        cOrigPropath = PROPATH
+        cNewPropath  = cEnvDir + "\" + fiEnvironment:{&SV} + "\Programs," + PROPATH
+        PROPATH = cNewPropath.
+        
+    RUN ipStatus ("    Convert GLTrans to GLHist...").
+    RUN util/ConversionGLTrans.p.
+    
+    RUN ipStatus ("    Verifying GLHist record data...").
+    RUN util/SetGLHistFlag.p.
+
+    ASSIGN 
+        PROPATH = cOrigPropath.     
+
+END PROCEDURE.
+	
+/* _UIB-CODE-BLOCK-END */
+&ANALYZE-RESUME
+
+
+
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipConvertJcCtrl C-Win 
 PROCEDURE ipConvertJcCtrl :
 /*------------------------------------------------------------------------------
@@ -2681,8 +2713,6 @@ PROCEDURE ipDataFix :
         RUN ipDataFix200303.
     IF iCurrentVersion LT 21000100 THEN
         RUN ipDataFix210001.
-    IF iCurrentVersion LT 21000200 THEN
-        RUN ipDataFix210002.
     IF iCurrentVersion LT 21000300 THEN
         RUN ipDataFix210003.
     IF iCurrentVersion LT 99999999 THEN
@@ -3411,34 +3441,6 @@ END PROCEDURE.
 &ANALYZE-RESUME
 
 
-
-
-&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipDataFix210002 C-Win
-PROCEDURE ipDataFix210002:
-/*------------------------------------------------------------------------------
- Purpose:
- Notes:
-------------------------------------------------------------------------------*/
-    DEF VAR cOrigPropath AS CHAR NO-UNDO.
-    DEF VAR cNewPropath AS CHAR NO-UNDO.
-
-    RUN ipStatus ("  Data Fix 210002...").
-
-    ASSIGN
-        cOrigPropath = PROPATH
-        cNewPropath  = cEnvDir + "\" + fiEnvironment:{&SV} + "\Programs," + PROPATH
-        PROPATH = cNewPropath.
-        
-    RUN util/ConversionGLTrans.p.
-    
-    ASSIGN 
-        PROPATH = cOrigPropath.     
-
-END PROCEDURE.
-	
-/* _UIB-CODE-BLOCK-END */
-&ANALYZE-RESUME
-
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipDataFix210003 C-Win
 PROCEDURE ipDataFix210003:
 /*------------------------------------------------------------------------------
@@ -3478,6 +3480,7 @@ PROCEDURE ipDataFix999999 :
     RUN ipChangeCostMethod.
     RUN ipSetDepartmentRequired.
     RUN ipAddDbmsFonts.
+    RUN ipConvertGLTrans.
     RUN ipDeleteAudit.
     
 END PROCEDURE.

--- a/Source/util/SetGLHistFlag.p
+++ b/Source/util/SetGLHistFlag.p
@@ -13,22 +13,27 @@
   DEFINE BUFFER bf-glhist FOR glhist.
   DEFINE BUFFER bf-period FOR period.
   DEFINE BUFFER bf-first-open-period FOR period.
-  FOR EACH bf-glhist :
+  
+  /* Only process records where the glyear has not been set OR record is not posted 
+     Otherwise, this will try to lock and process EVERY glhist */
+  FOR EACH bf-glhist EXCLUSIVE WHERE
+    bf-glhist.glYear EQ 0 OR 
+    bf-glhist.posted EQ NO:
        
     FIND FIRST bf-period NO-LOCK
-         where bf-period.company eq bf-glhist.company
-         and bf-period.pst  le bf-glhist.tr-date
-         and bf-period.pend ge bf-glhist.tr-date          
+        WHERE bf-period.company EQ bf-glhist.company
+        AND bf-period.pst  LE bf-glhist.tr-date
+        AND bf-period.pend GE bf-glhist.tr-date          
         NO-ERROR.             
-      
-     bf-glhist.glYear = IF AVAIL bf-period THEN bf-period.yr ELSE bf-glhist.glYear.
+     IF AVAIL bf-period THEN ASSIGN  
+        bf-glhist.glYear = bf-period.yr.
      
      FIND FIRST bf-first-open-period NO-LOCK
-          WHERE bf-first-open-period.company EQ bf-glhist.company
-          AND bf-first-open-period.pstat   EQ YES
-          NO-ERROR.
-     IF (AVAIL bf-first-open-period AND bf-glhist.tr-date LT bf-first-open-period.pst) OR NOT AVAIL bf-period THEN       
-     ASSIGN
+        WHERE bf-first-open-period.company EQ bf-glhist.company
+        AND bf-first-open-period.pstat   EQ YES
+        NO-ERROR.
+     IF (AVAIL bf-first-open-period AND bf-glhist.tr-date LT bf-first-open-period.pst) 
+     OR NOT AVAIL bf-period THEN ASSIGN
          bf-glhist.posted = YES
          bf-glhist.entryType = "A".      
      


### PR DESCRIPTION
Programs changed:
asiUpdateENV.w - moved convert/set updateGLHist to separate procedure to be run on every upgrade
(this replaces ipDataFix210002)
util/SetGLHistFlag.p
modified to ONLY process glhist records where glyear = 0 or posted = no
without this change, EVERY GL hist reocrd is locked and processed
for Premier, this would by 7.7MM+ records