### PR TITLE
97907 Update/rewrite ASI Login

### DIFF
--- a/Deployment/BuildScript/ToCompile/asiLogin.w
+++ b/Deployment/BuildScript/ToCompile/asiLogin.w
@@ -511,7 +511,8 @@ DO:
         WHEN "cbEnvironment" THEN DO:
             RUN ipChangeEnvironment.
             ASSIGN 
-                cbDatabase:SENSITIVE = NUM-ENTRIES(cDbValidList) GT 1.
+                cbDatabase:SENSITIVE = NUM-ENTRIES(cDbValidList) GT 1
+                cbDatabase:SCREEN-VALUE = ENTRY(1,cbDatabase:LIST-ITEMS).
         END.
         WHEN "cbMode" THEN RUN ipChangeMode.
     END CASE.

--- a/Deployment/BuildScript/ToCompile/iniFileVars.i
+++ b/Deployment/BuildScript/ToCompile/iniFileVars.i
@@ -39,7 +39,7 @@ ASSIGN cIniVarList =
     "# Audit DB List,audDbList,audVerList,audDirList,audPortList," +
     "# Basic DB Elements,audDbName,audDbPort,audDbStFile,prodDbName,prodDbPort,prodDbStFile,shipDbName,shipDbPort,shipDbStFile,testDbName,testDbPort,testDbStFile," +
     "# API Elements,apiIPAddress,apiPort,adminPort,nameServerName,nameServerPort,appServerName,appServerPort," +
-    "# Misc Elements,dfFileName,deltaFileName".
+    "# Misc Elements,dfFileName,deltaFileName,isHyperV".
 
 /* # Setup Variables */
 DEF VAR cSitename AS CHAR INITIAL "ASI" NO-UNDO.
@@ -155,7 +155,7 @@ DEF VAR cAppServerPort AS CHAR INITIAL "3092" NO-UNDO.
 /* # Misc Elements */
 DEF VAR cDfFileName AS CHAR INITIAL "asi167.df" NO-UNDO.
 DEF VAR cDeltaFileName AS CHAR INITIAL "asi166167.df" NO-UNDO.
-
+DEF VAR cIsHyperV AS CHAR INITIAL "NO" NO-UNDO.
 DEF VAR cOutAdminPort AS CHAR NO-UNDO.
 DEF VAR cOutAppServerName AS CHAR INITIAL "Advantzware_API" NO-UNDO.
 DEF VAR cOutAppServerPort AS CHAR NO-UNDO.
@@ -491,6 +491,7 @@ PROCEDURE ipReadIniFile:
                 WHEN "testDbStFile" THEN ASSIGN      ttIniFile.cVarValue = cTestDbStFile.
                 WHEN "dfFileName" THEN ASSIGN        ttIniFile.cVarValue = cDfFileName.
                 WHEN "deltaFileName" THEN ASSIGN     ttIniFile.cVarValue = cDeltaFileName.
+                WHEN "isHyperV" THEN ASSIGN          ttIniFile.cVarValue = cIsHyperV.
                 WHEN "apiIPAddress" THEN ASSIGN      ttIniFile.cVarValue = cAPIIpAddress.
                 WHEN "apiPort" THEN ASSIGN           ttIniFile.cVarValue = cAPIPort.
                 WHEN "adminPort" THEN ASSIGN         ttIniFile.cVarValue = cAdminPort.
@@ -591,6 +592,7 @@ PROCEDURE ipReadIniFile:
             WHEN "testDbStFile" THEN ASSIGN     cTestDbStFile       = ttIniFile.cVarValue.
             WHEN "dfFileName" THEN ASSIGN       cDfFileName         = ttIniFile.cVarValue.
             WHEN "deltaFileName" THEN ASSIGN    cDeltaFileName      = ttIniFile.cVarValue.
+            WHEN "isHyperV" THEN ASSIGN         cIsHyperV           = ttIniFile.cVarValue.
             WHEN "apiIPAddress" THEN ASSIGN     cAPIIpAddress       = ttIniFile.cVarValue.
             WHEN "apiPort" THEN ASSIGN          cAPIPort            = ttIniFile.cVarValue.
             WHEN "adminPort" THEN ASSIGN        cAdminPort          = ttIniFile.cVarValue.


### PR DESCRIPTION
This checkin also has (temporary?) fix for #98154 (image files in Hyper-V)
Programs changed:
asiLogin.w
lines 511-517 - applies entry to database selector if multiple DBs are available
line 591 - selects first environment available in ini file and sets up db list properly
lines 649-654 - same as above
line 743 - ensures userid is set properly when running in batch mode
lines 780-791 - syntax cleanup
lines 840-842, 882-884 - removes conditional use of PL files
line 906 - syntax cleanup
lines 951-960 - handles local copy of PL files from server to local, and in propath

iniFileVars.i
lines 42,158,494,595 - adds support for "isHyperV" flag in advantzware.ini file