### PR TITLE
100066 Allow NM utility to run programs without .r extension

### DIFF
--- a/Source/util/b-utilsN.w
+++ b/Source/util/b-utilsN.w
@@ -540,14 +540,22 @@ DO:
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _CONTROL btnRun B-table-Win
 ON CHOOSE OF btnRun IN FRAME F-Main /* Run */
 DO:
-    IF NOT AVAILABLE utilities THEN 
-        RETURN NO-APPLY.
-    IF SEARCH('util/' + utilities.programName) NE ? THEN
-        RUN VALUE('util/' + utilities.programName).
-    ELSE IF SEARCH('util/' + utilities.programName + '.r') NE ? THEN
-        RUN VALUE('util/' + utilities.programName + '.r').
+    DEF VAR cUnExtended AS CHAR NO-UNDO.
+    /* removes any extenstion from the value entered, if any */
+    ASSIGN 
+        cUnextended = REPLACE(fi_pro-name:SCREEN-VALUE IN FRAME {&frame-name},".r","")
+        cUnextended = REPLACE(fi_pro-name:SCREEN-VALUE,".w","")
+        cUnextended = REPLACE(fi_pro-name:SCREEN-VALUE,".p","")
+        cUnextended = REPLACE(fi_pro-name:SCREEN-VALUE,".","").
+    /* Searches for source code (and if found, runs it), THEN for r-code */
+    IF SEARCH(cUnextended + '.w') NE ? THEN
+        RUN VALUE('util/' + cUnextended + '.w').
+    ELSE IF SEARCH('util/' + cUnextended + '.p') NE ? THEN
+        RUN VALUE('util/' + cUnextended + '.p').
+    ELSE IF SEARCH('util/' + cUnextended + '.r') NE ? THEN
+        RUN VALUE('util/' + cUnextended + '.r').
     ELSE MESSAGE 
-        'Program: util/' + utilities.programName + ' does not exist!' VIEW-AS ALERT-BOX.
+        'Program: util/' + cUnextended + ' does not exist with any extension.' VIEW-AS ALERT-BOX.
 END.
 
 /* _UIB-CODE-BLOCK-END */

--- a/Source/util/b-utilsN.w
+++ b/Source/util/b-utilsN.w
@@ -544,11 +544,12 @@ DO:
     /* removes any extenstion from the value entered, if any */
     ASSIGN 
         cUnextended = REPLACE(fi_pro-name:SCREEN-VALUE IN FRAME {&frame-name},".r","")
-        cUnextended = REPLACE(fi_pro-name:SCREEN-VALUE,".w","")
-        cUnextended = REPLACE(fi_pro-name:SCREEN-VALUE,".p","")
-        cUnextended = REPLACE(fi_pro-name:SCREEN-VALUE,".","").
+        cUnextended = REPLACE(cUnextended,".w","")
+        cUnextended = REPLACE(cUnextended,".p","")
+        cUnextended = REPLACE(cUnextended,".","").
+
     /* Searches for source code (and if found, runs it), THEN for r-code */
-    IF SEARCH(cUnextended + '.w') NE ? THEN
+    IF SEARCH('util/' + cUnextended + '.w') NE ? THEN
         RUN VALUE('util/' + cUnextended + '.w').
     ELSE IF SEARCH('util/' + cUnextended + '.p') NE ? THEN
         RUN VALUE('util/' + cUnextended + '.p').

--- a/Source/util/v-utilsN.w
+++ b/Source/util/v-utilsN.w
@@ -260,11 +260,12 @@ DO:
     /* removes any extenstion from the value entered, if any */
     ASSIGN 
         cUnextended = REPLACE(utilities.programName:SCREEN-VALUE IN FRAME {&frame-name},".r","")
-        cUnextended = REPLACE(utilities.programName:SCREEN-VALUE,".w","")
-        cUnextended = REPLACE(utilities.programName:SCREEN-VALUE,".p","")
-        cUnextended = REPLACE(utilities.programName:SCREEN-VALUE,".","").
+        cUnextended = REPLACE(cUnextended,".w","")
+        cUnextended = REPLACE(cUnextended,".p","")
+        cUnextended = REPLACE(cUnextended,".","").
+
     /* Searches for source code (and if found, runs it), THEN for r-code */
-    IF SEARCH(cUnextended + '.w') NE ? THEN
+    IF SEARCH('util/' + cUnextended + '.w') NE ? THEN
         RUN VALUE('util/' + cUnextended + '.w').
     ELSE IF SEARCH('util/' + cUnextended + '.p') NE ? THEN
         RUN VALUE('util/' + cUnextended + '.p').
@@ -274,7 +275,6 @@ DO:
         'Program: util/' + cUnextended + ' does not exist with any extension.' VIEW-AS ALERT-BOX.
 
 END.
-
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
 

--- a/Source/util/v-utilsN.w
+++ b/Source/util/v-utilsN.w
@@ -638,15 +638,25 @@ PROCEDURE local-update-record :
             utilities.securityLevel:SCREEN-VALUE = STRING(iBaseLevel).
         RETURN NO-APPLY.
     END.
-    IF INDEX(utilities.programName:SCREEN-VALUE,".r") EQ 0 THEN DO:
-        MESSAGE 
-            "You are about to save an uncompiled program record." SKIP 
-            "This is not recommended.  Convert to compiled version?"
-            VIEW-AS ALERT-BOX QUESTION BUTTONS YES-NO UPDATE lCompiled AS LOG.
-        IF lCompiled THEN ASSIGN 
-            SELF:SCREEN-VALUE = REPLACE(SELF:SCREEN-VALUE,".p",".r")
-            SELF:SCREEN-VALUE = REPLACE(SELF:SCREEN-VALUE,".w",".r")
-            .
+    IF lAddRecord THEN DO:
+        IF CAN-FIND (FIRST utilities WHERE 
+            utilities.programName = utilities.programName:SCREEN-VALUE) THEN DO:
+            MESSAGE 
+                "You are trying to add a new utility with the same" SKIP 
+                "name as an existing utility.  This is not allowed."
+                VIEW-AS ALERT-BOX ERROR.
+            RETURN NO-APPLY.
+        END.
+        ELSE IF INDEX(utilities.programName:SCREEN-VALUE,".r") EQ 0 THEN DO:
+            MESSAGE 
+                "You are about to save an uncompiled program record." SKIP 
+                "This is not recommended.  Convert to compiled version?"
+                VIEW-AS ALERT-BOX QUESTION BUTTONS YES-NO UPDATE lCompiled AS LOG.
+            IF lCompiled THEN ASSIGN 
+                utilities.programName:SCREEN-VALUE = REPLACE(utilities.programName:SCREEN-VALUE,".p",".r")
+                utilities.programName:SCREEN-VALUE = REPLACE(utilities.programName:SCREEN-VALUE,".w",".r")
+                .
+        END.
     END. 
     
     RUN dispatch IN THIS-PROCEDURE ( INPUT 'update-record':U ) .

--- a/Source/util/v-utilsN.w
+++ b/Source/util/v-utilsN.w
@@ -256,14 +256,10 @@ ASSIGN
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _CONTROL btnRun V-table-Win
 ON CHOOSE OF btnRun IN FRAME F-Main /* Run */
 DO:
-    IF NOT AVAILABLE utilities THEN 
-        RETURN NO-APPLY.
-    IF SEARCH('util/' + utilities.programName) NE ? THEN
-        RUN VALUE('util/' + utilities.programName).
-    ELSE IF SEARCH('util/' + utilities.programName + '.r') NE ? THEN
-        RUN VALUE('util/' + utilities.programName + '.r').
+    IF SEARCH('util/' + utilities.programName:SCREEN-VALUE IN FRAME {&frame-name}) NE ? THEN
+        RUN VALUE('util/' + utilities.programName:SCREEN-VALUE).
     ELSE MESSAGE 
-        'Program: util/' + utilities.programName + ' does not exist!' VIEW-AS ALERT-BOX.
+        'Program: util/' + utilities.programName:SCREEN-VALUE + ' does not exist!' VIEW-AS ALERT-BOX.
 END.
 
 /* _UIB-CODE-BLOCK-END */
@@ -300,10 +296,10 @@ END.
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _CONTROL utilities.programName V-table-Win
 ON LEAVE OF utilities.programName IN FRAME F-Main /* Program Name */
 DO:
-    IF INDEX(SELF:SCREEN-VALUE,'util/') NE 0 THEN ASSIGN 
+    ASSIGN  
         SELF:SCREEN-VALUE = REPLACE(SELF:SCREEN-VALUE,'util/','').
     IF SEARCH('util/' + SELF:SCREEN-VALUE) EQ ? 
-    AND SEARCH('util/' + SELF:SCREEN-VALUE + ".r") EQ ? THEN DO:
+    THEN DO:
         MESSAGE 
             "This program does not exist in the /util directory." SKIP 
             "Please correct this condition immediately."
@@ -642,6 +638,16 @@ PROCEDURE local-update-record :
             utilities.securityLevel:SCREEN-VALUE = STRING(iBaseLevel).
         RETURN NO-APPLY.
     END.
+    IF INDEX(utilities.programName:SCREEN-VALUE,".r") EQ 0 THEN DO:
+        MESSAGE 
+            "You are about to save an uncompiled program record." SKIP 
+            "This is not recommended.  Convert to compiled version?"
+            VIEW-AS ALERT-BOX QUESTION BUTTONS YES-NO UPDATE lCompiled AS LOG.
+        IF lCompiled THEN ASSIGN 
+            SELF:SCREEN-VALUE = REPLACE(SELF:SCREEN-VALUE,".p",".r")
+            SELF:SCREEN-VALUE = REPLACE(SELF:SCREEN-VALUE,".w",".r")
+            .
+    END. 
     
     RUN dispatch IN THIS-PROCEDURE ( INPUT 'update-record':U ) .
     

--- a/Source/util/v-utilsN.w
+++ b/Source/util/v-utilsN.w
@@ -256,10 +256,23 @@ ASSIGN
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _CONTROL btnRun V-table-Win
 ON CHOOSE OF btnRun IN FRAME F-Main /* Run */
 DO:
-    IF SEARCH('util/' + utilities.programName:SCREEN-VALUE IN FRAME {&frame-name}) NE ? THEN
-        RUN VALUE('util/' + utilities.programName:SCREEN-VALUE).
+    DEF VAR cUnExtended AS CHAR NO-UNDO.
+    /* removes any extenstion from the value entered, if any */
+    ASSIGN 
+        cUnextended = REPLACE(utilities.programName:SCREEN-VALUE IN FRAME {&frame-name},".r","")
+        cUnextended = REPLACE(utilities.programName:SCREEN-VALUE,".w","")
+        cUnextended = REPLACE(utilities.programName:SCREEN-VALUE,".p","")
+        cUnextended = REPLACE(utilities.programName:SCREEN-VALUE,".","").
+    /* Searches for source code (and if found, runs it), THEN for r-code */
+    IF SEARCH(cUnextended + '.w') NE ? THEN
+        RUN VALUE('util/' + cUnextended + '.w').
+    ELSE IF SEARCH('util/' + cUnextended + '.p') NE ? THEN
+        RUN VALUE('util/' + cUnextended + '.p').
+    ELSE IF SEARCH('util/' + cUnextended + '.r') NE ? THEN
+        RUN VALUE('util/' + cUnextended + '.r').
     ELSE MESSAGE 
-        'Program: util/' + utilities.programName:SCREEN-VALUE + ' does not exist!' VIEW-AS ALERT-BOX.
+        'Program: util/' + cUnextended + ' does not exist with any extension.' VIEW-AS ALERT-BOX.
+
 END.
 
 /* _UIB-CODE-BLOCK-END */
@@ -296,9 +309,12 @@ END.
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _CONTROL utilities.programName V-table-Win
 ON LEAVE OF utilities.programName IN FRAME F-Main /* Program Name */
 DO:
+    
     ASSIGN  
         SELF:SCREEN-VALUE = REPLACE(SELF:SCREEN-VALUE,'util/','').
     IF SEARCH('util/' + SELF:SCREEN-VALUE) EQ ? 
+    AND SEARCH('util/' + SELF:SCREEN-VALUE + ".r") EQ ?
+    AND SEARCH('util/' + SELF:SCREEN-VALUE + "r") EQ ?
     THEN DO:
         MESSAGE 
             "This program does not exist in the /util directory." SKIP 
@@ -638,27 +654,7 @@ PROCEDURE local-update-record :
             utilities.securityLevel:SCREEN-VALUE = STRING(iBaseLevel).
         RETURN NO-APPLY.
     END.
-    IF lAddRecord THEN DO:
-        IF CAN-FIND (FIRST utilities WHERE 
-            utilities.programName = utilities.programName:SCREEN-VALUE) THEN DO:
-            MESSAGE 
-                "You are trying to add a new utility with the same" SKIP 
-                "name as an existing utility.  This is not allowed."
-                VIEW-AS ALERT-BOX ERROR.
-            RETURN NO-APPLY.
-        END.
-        ELSE IF INDEX(utilities.programName:SCREEN-VALUE,".r") EQ 0 THEN DO:
-            MESSAGE 
-                "You are about to save an uncompiled program record." SKIP 
-                "This is not recommended.  Convert to compiled version?"
-                VIEW-AS ALERT-BOX QUESTION BUTTONS YES-NO UPDATE lCompiled AS LOG.
-            IF lCompiled THEN ASSIGN 
-                utilities.programName:SCREEN-VALUE = REPLACE(utilities.programName:SCREEN-VALUE,".p",".r")
-                utilities.programName:SCREEN-VALUE = REPLACE(utilities.programName:SCREEN-VALUE,".w",".r")
-                .
-        END.
-    END. 
-    
+     
     RUN dispatch IN THIS-PROCEDURE ( INPUT 'update-record':U ) .
     
     ASSIGN


### PR DESCRIPTION
Program changed: util/v-utilsN.w
on CHOOSE of run button - run the program in /util with the name indicated in the program name fill-in
on LEAVE of programname - allow entry of .p or .w files
on SAVE of record - if program name contains ".w" or ".p", prompt to change to ".r"