### PR TITLE
100463 NQ1 extracts fixes to Override root without preserving dir names

### DIFF
--- a/Source/system/wUpdateHst.w
+++ b/Source/system/wUpdateHst.w
@@ -464,7 +464,7 @@ PROCEDURE ipInstallPatch:
                     '\Hotfix' + cPatchToProcess + '.zip -s'.
         OS-COMMAND SILENT VALUE(cCmd).
         ASSIGN 
-            cCmd =  'CALL "c:\program files\7-zip\7z.exe"  e ' + cOverrideDir + '\Hotfix' + cPatchToProcess + '.zip -o' + cOverrideDir + ' -aoa'. 
+            cCmd =  'CALL "c:\program files\7-zip\7z.exe"  x ' + cOverrideDir + '\Hotfix' + cPatchToProcess + '.zip -o' + cOverrideDir + ' -aoa'. 
         OS-COMMAND SILENT VALUE(cCmd).
 
         INPUT FROM VALUE (cOverrideDir + "\HotfixList.txt").


### PR DESCRIPTION
program changed: system/wUpdateHst.w - fixed 7zip command line