### PR TITLE
100185 Global- User Module Access Not Properly Applied

### DIFF
--- a/Deployment/BuildScript/ToCompile/asiLogin.w
+++ b/Deployment/BuildScript/ToCompile/asiLogin.w
@@ -116,13 +116,11 @@ DEFINE VARIABLE iLockoutTries AS INT NO-UNDO.
 DEFINE VARIABLE iModePos AS INT NO-UNDO.
 DEFINE VARIABLE intBufferSize AS INTEGER NO-UNDO INITIAL 256.
 DEFINE VARIABLE intResult AS INTEGER NO-UNDO.
-DEFINE VARIABLE iNumUsers AS INT NO-UNDO.
 DEFINE VARIABLE is-running AS LOGICAL NO-UNDO.
 DEFINE VARIABLE iTries AS INT NO-UNDO.
 DEFINE VARIABLE iTruncLevel AS INT NO-UNDO.
 DEFINE VARIABLE jCtr AS INT NO-UNDO.
 DEFINE VARIABLE lConnectAudit AS LOG NO-UNDO.
-DEFINE VARIABLE lCorrupt AS LOG NO-UNDO.
 DEFINE VARIABLE ldummy AS LOGICAL NO-UNDO.
 DEFINE VARIABLE lExit AS LOGICAL NO-UNDO.
 DEFINE VARIABLE lFound AS LOGICAL NO-UNDO.
@@ -528,10 +526,12 @@ ON LEAVE OF fiUserID IN FRAME DEFAULT-FRAME /* User ID */
 DO:
     RUN ipAssignSV.
     FIND FIRST ttUsers NO-LOCK WHERE
-        ttUsers.ttfUserID = fiUserID
+        ttUsers.ttfUserID EQ fiUserID AND 
+        ttUsers.ttfPdbName EQ "*"
         NO-ERROR.
     IF NOT AVAIL ttUsers THEN FIND FIRST ttUsers NO-LOCK WHERE
-        ttUsers.ttfUserAlias = fiUserID
+        ttUsers.ttfUserAlias EQ fiUserID AND 
+        ttUsers.ttfPdbName EQ "*"
         NO-ERROR.
 
     IF NOT AVAIL ttUsers THEN DO:
@@ -562,8 +562,6 @@ DO:
             SELF:SCREEN-VALUE = "".
         RETURN NO-APPLY.
     END.
-    
-
     
     ASSIGN
         /* set the combo box possible values */
@@ -1341,10 +1339,6 @@ PROCEDURE ipPreRun :
         END.
     END.
      
-    RUN epUpdateUsrFile IN hPreRun (OUTPUT cUsrList).
-
-    RUN ipUpdUsrFile IN THIS-PROCEDURE (cUsrList).
-
     RUN epGetUserGroups IN hPreRun (OUTPUT g_groups).
 
     IF iDbLevel GT 16061200 THEN 
@@ -1374,9 +1368,6 @@ PROCEDURE ipReadUsrFile :
       Parameters:  <none>
       Notes:       
     ------------------------------------------------------------------------------*/
-    ASSIGN 
-        lCorrupt = FALSE
-        iCtr = 1.
     INPUT FROM VALUE(SEARCH(cUsrLoc)).
     REPEAT:
         IMPORT UNFORMATTED cUsrLine.
@@ -1390,12 +1381,10 @@ PROCEDURE ipReadUsrFile :
                 ttUsers.ttfEnvList = ENTRY(4,cUsrLine,"|")
                 ttUsers.ttfDbList = ENTRY(5,cUsrLine,"|")
                 ttUsers.ttfModeList = ENTRY(6,cUsrLine,"|")
-                iCtr = iCtr + 1.
+                .
         END.
     END.
     INPUT CLOSE.
-    ASSIGN
-        iNumUsers = iCtr.
 
 END PROCEDURE.
 
@@ -1429,95 +1418,6 @@ PROCEDURE ipSetCurrentDir :
     END.
     &ENDIF
 
-END PROCEDURE.
-
-/* _UIB-CODE-BLOCK-END */
-&ANALYZE-RESUME
-
-&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipUpdUsrFile C-Win 
-PROCEDURE ipUpdUsrFile :
-/*------------------------------------------------------------------------------
-      Purpose:     
-      Parameters:  <none>
-      Notes:       The ONLY reason to run this is if in "healing" mode; i.e there's been
-                   a change to the structure of the .usr file or the ttUsers temp-table
-    ------------------------------------------------------------------------------*/
-    DEF INPUT PARAMETER ipcUserList AS CHAR NO-UNDO.
-    DEFINE VARIABLE iCtr AS INT NO-UNDO.
-    DEFINE VARIABLE cOutString AS CHAR.
-    DEFINE VARIABLE cUserModes AS CHAR NO-UNDO.
-    
-    DEFINE BUFFER bttUsers FOR ttUsers.
-
-    /* ipcUserList is a list of all _user records in the connected DBs. */
-    ASSIGN 
-        lUpdUsr = FALSE.
-    
-    /* If we haven't previiously deleted the DB-specific records, do it now. */    
-    IF CAN-FIND (FIRST ttUsers WHERE 
-                ttUsers.ttfPdbName NE "*") THEN DO:
-        ASSIGN 
-            lUpdUsr = TRUE.
-        FOR EACH ttUsers WHERE 
-            ttUsers.ttfPdbName NE "*":
-            DELETE ttUsers.
-        END.
-    END.   
-    
-    /* If a new user has been created in the DB, add to .usr file */
-    DO iCtr = 1 TO NUM-ENTRIES(ipcUserList):
-        FIND FIRST bttUsers WHERE 
-            ttUsers.ttfUserID EQ ENTRY(iCtr,ipcUserList) AND
-            ttUsers.ttfPdbName EQ "PROD"
-            NO-LOCK NO-ERROR.
-        IF AVAIL bttUsers THEN ASSIGN 
-            cUserModes = bttUsers.ttfModeList.
-        ELSE ASSIGN
-            cUserModes = "".
-
-        FOR EACH bttUsers WHERE 
-            bttUsers.ttfUserID EQ ENTRY(iCtr,ipcUserList) AND
-            bttUsers.ttfPdbName NE "*":
-            DELETE ttUsers.
-        END.
-
-        FIND FIRST ttUsers WHERE
-            ttUsers.ttfUserID EQ ENTRY(iCtr,ipcUserList) AND
-            ttUsers.ttfPdbName EQ "*"
-            NO-ERROR.
-        IF NOT AVAIL ttUsers THEN DO:
-            CREATE ttUsers.
-            ASSIGN
-                lUpdUsr = TRUE
-                ttUsers.ttfUserID = ENTRY(iCtr,ipcUserList)
-                ttUsers.ttfUserAlias = ENTRY(iCtr,ipcUserList)
-                ttUsers.ttfPdbName = "*"
-                ttUsers.ttfModeList = cUserModes
-                .
-        END.
-        ELSE IF ttUsers.ttfModeList EQ "" 
-        AND cUserModes NE "" THEN ASSIGN 
-            lUpdUsr = TRUE
-            ttUsers.ttfModeList = cUserModes.
-        
-    END.
-    
-    IF lUpdUsr = TRUE THEN DO:
-        OUTPUT STREAM usrStream TO VALUE(cUsrLoc).
-        FOR EACH ttUsers by ttUsers.ttfUserID:
-            ASSIGN 
-                cOutString = 
-                ttUsers.ttfUserID + "|" + 
-                ttUsers.ttfPdbName + "|" +
-                ttUsers.ttfUserAlias + "|" + 
-                ttUsers.ttfEnvList + "|" +
-                ttUsers.ttfDbList + "|" +
-                ttUsers.ttfModeList.
-            PUT STREAM usrStream UNFORMATTED cOutString + CHR(10).
-        END.
-        OUTPUT STREAM usrStream CLOSE.
-    END.
-    
 END PROCEDURE.
 
 /* _UIB-CODE-BLOCK-END */

--- a/Source/viewers/users.w
+++ b/Source/viewers/users.w
@@ -90,6 +90,10 @@ DEFINE TEMP-TABLE ttUsers
         INDEX iUserID   IS UNIQUE ttfUserID  ttfPdbName
         INDEX iDatabase IS UNIQUE ttfPdbName ttfUserID
         .
+        
+DEFINE TEMP-TABLE ttModes
+    FIELD ttfMode AS CHAR.
+            
 DEFINE BUFFER bttUsers FOR ttUsers.
 
 /* _UIB-CODE-BLOCK-END */
@@ -1674,6 +1678,98 @@ END PROCEDURE.
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME
 
+
+&ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipCleanUsrFile V-table-Win
+PROCEDURE ipCleanUsrFile:
+/*------------------------------------------------------------------------------
+ Purpose:   Clean up old structure of advantzware.usr file (with per-database mode lists) into single list at master level
+ Notes:     The "old" structure contained a "master" record for each user that controlled environments and databases.
+     It also contained "per-database" records (keys userid/pdbname) that controlled valid modes per userid/database.
+     
+     What we want to do here is simplify that file and move the "per-database" mode limits up to the "master" record.
+     (A longer-term goal is to get this information into database data, rather than a filesystem file, but since the
+     asiLogin program, which uses this file, is not connected to a database when it is run, this is still problematic.)
+     
+     Note that we also have to be mindful of "two-version" installations, where the earlier version of this program will
+     still be able to create "per-database" records in this file, even though the asiLogin program will ignore them, 
+     regardless of version, as soon as this release (21.02) is installed.  For that reason, we need to continue this cleanup
+     process here (and in asiLogin.w) as long as there are active pre-21.02 versions in the field.
+     
+     Note also that this procedure is ONLY run if the program detects that there is a "bad" (i.e. per-database) record in advantzware.usr
+------------------------------------------------------------------------------*/
+    DEF VAR cModeTest AS CHAR NO-UNDO.
+    DEF VAR iCtr AS INT NO-UNDO.
+    DEF VAR lCleaned AS LOG NO-UNDO.
+    
+    /* ttUsers is an internal image of the advantzware.usr file */
+    /* We're going to read each line (later in this block, we eliminate "per-db" lines) */
+    FOR EACH ttUsers:
+        
+        /* ...then empty our internal temp-table of the modes allowed */
+        EMPTY TEMP-TABLE ttModes.
+        
+        /* Now, IF the line is the "master" (where pdbnbame is "*"), AND there have been no mode limits set, keep going, 
+        otherwise skip this user, because the streamline process has already been run for him/her */
+        IF ttUsers.ttfPdbname EQ "*" THEN DO:                           /* Is this the master record? */
+            
+            IF ttUsers.ttfModeList EQ "" THEN NEXT.                     /* SKIP user if the mode list been set at the master level already */
+            
+            ELSE DO:  
+                /* Look for any "per-database" lines that have limits set (this is where modes USED to be controlled) */
+                /* At the end of this loop, the ttModes table will contain all of the listed modes for all of the per-database lines */
+                FOR EACH bttUsers WHERE                                 /* buffer for same temp-table */
+                    bttUsers.ttfUserID EQ ttUsers.ttfUserID AND         /* userid matches */
+                    bttUsers.ttfPdbname NE "*" AND                      /* NOT the master record */
+                    bttUsers.ttfModeList NE "":                         /* per-database mode list has been set */
+                    
+                    DO iCtr = 1 TO NUM-ENTRIES(bttUsers.ttfModeList):   /* Loop through the mode entries for this database */
+                        IF NOT CAN-FIND(FIRST ttModes WHERE             /* skip any modes that were added from a previous database */
+                            ttModes.ttfMode EQ ENTRY(iCtr,bttUsers.ttfModeList)) THEN DO:
+                            CREATE ttModes.                             /* Create a ttModes record for each entry listed... */
+                            ASSIGN 
+                                ttModes.ttfMode = ENTRY(iCtr,bttUsers.ttfModeList).
+                        END.
+                    END.
+                    ASSIGN 
+                        lCleaned = TRUE.                                /* Set flag to notify mods made, and need to update the physical file */
+                END.
+            END.
+
+            /* Still in the same "per-user" loop, concatenate the ttModes entries into the single "master" limit for this user */
+            FOR EACH ttModes:
+                ASSIGN
+                    ttUsers.ttfModeList = ttUsers.ttfModeList + ttModes.ttfMode + ",".
+            END.
+            /* Just trimming the comma off the end of the list */
+            ASSIGN 
+                ttUsers.ttfModeList = TRIM(ttUsers.ttfModeList,",").
+
+        END.
+    END. 
+
+    /* Last, delete the "bad" ttUser records that contain per-database entries */
+    /* This will be written back out to advantzware.usr in ipWriteUserFile */
+    FOR EACH ttUsers WHERE 
+        ttUsers.ttfPdbname NE "*":
+        DELETE ttUsers.
+        ASSIGN 
+            lCleaned = TRUE.
+    END.                        
+
+    /* If we cleaned the file and updated the ttUsers table, write advantzware.usr file with changes and re-read */
+    IF lCleaned EQ TRUE THEN DO:
+        RUN ipWriteUsrFile.
+        EMPTY TEMP-TABLE ttUsers.
+        RUN ipReadUsrFile.
+    END. 
+            
+END PROCEDURE.
+	
+/* _UIB-CODE-BLOCK-END */
+&ANALYZE-RESUME
+
+
+
 &ANALYZE-SUSPEND _UIB-CODE-BLOCK _PROCEDURE ipReadIniFile V-table-Win 
 PROCEDURE ipReadIniFile :
 /*------------------------------------------------------------------------------
@@ -1729,6 +1825,12 @@ PROCEDURE ipReadUsrFile :
             END.
         END.
         INPUT CLOSE.
+        
+        /* IF detected "bad" line in advantzware.usr, run the cleanup procedure */
+        IF CAN-FIND(FIRST ttUsers WHERE 
+            ttUsers.ttfPdbname NE "*") THEN 
+            RUN ipCleanUsrFile.
+        
     END.
 
 END PROCEDURE.
@@ -1741,7 +1843,9 @@ PROCEDURE ipWriteUsrFile :
 /*------------------------------------------------------------------------------
   Purpose:     
   Parameters:  <none>
-  Notes:       
+  Notes:    This is ONLY run if:
+                1 - a user is deleted, added, or modified 
+                2 - the ipClean procedure was run and found a bad record 
 ------------------------------------------------------------------------------*/
     DEF VAR cOutString AS CHAR.
     
@@ -1994,7 +2098,7 @@ PROCEDURE local-display-fields :
     RUN dispatch IN THIS-PROCEDURE ( INPUT 'display-fields':U ) .
     
     IF AVAIL users THEN DO WITH FRAME {&frame-name}:
-        /* Most elements come from the 'generic' ttUser (ttfPdbname = '*') */
+        /* "Limit" elements come from the 'generic' ttUser (ttfPdbname = '*') */
         FIND FIRST ttUsers WHERE
             ttUsers.ttfPdbName = "*" AND
             ttUsers.ttfUserID = users.user_id
@@ -2003,18 +2107,7 @@ PROCEDURE local-display-fields :
             CREATE ttUsers.
             ASSIGN
                 ttUsers.ttfPdbName = "*"
-                ttUsers.ttfUserID = users.user_id
-                .
-/* 39245 - User MODE does not save - 12/10/18 - MYT - remove references to db-based fields; use .usr file only */
-/*                IF ttUsers.ttfEnvlist EQ "" THEN                                                                  */
-/*                  ttUsers.ttfEnvList = IF users.envList GT "" THEN REPLACE(users.envList, "|", ",") ELSE "".      */
-/*                IF ttUsers.ttfDbList EQ "" THEN                                                                   */
-/*                  ttUsers.ttfDbList = IF users.dbList GT "" THEN REPLACE(users.dbList, "|", ",") ELSE "".         */
-/*                IF ttUsers.ttfUserAlias EQ "" THEN                                                                */
-/*                  ttUsers.ttfUserAlias = IF users.userAlias GT "" THEN REPLACE(users.userAlias, "|", ",") ELSE "".*/
-/*                IF ttUsers.ttfModeList EQ "" THEN                                                                 */
-/*                  ttUsers.ttfModeList = IF users.modeList GT "" THEN REPLACE(users.modeList, "|", ",") ELSE "".   */
-            
+                ttUsers.ttfUserID = users.user_id.
         END.
 
         ASSIGN 
@@ -2023,6 +2116,7 @@ PROCEDURE local-display-fields :
             cbUserType:screen-value = users.userType
             slEnvironments:screen-value = if ttUsers.ttfEnvList <> "" THEN ttUsers.ttfEnvList else slEnvironments:list-items
             slDatabases:screen-value = if ttUsers.ttfDbList <> "" THEN ttUsers.ttfDbList else slDatabases:list-items
+            slModes:SCREEN-VALUE = IF ttUsers.ttfModeList <> "" THEN ttUsers.ttfModeList ELSE slModes:LIST-ITEMS 
             users.userAlias:SCREEN-VALUE = users.userAlias
             users.userAlias:modified = FALSE
             FGColor-1:BGCOLOR = users.menuFGColor[1]
@@ -2033,37 +2127,20 @@ PROCEDURE local-display-fields :
             BGColor-3:BGCOLOR = users.menuBGColor[3]
             .
 
-        /* But mode-list has a by-db component (ttfPdbname = pdbname(1)) */
-        FIND FIRST ttUsers WHERE
-            ttUsers.ttfPdbName = PDBNAME(1) AND
-            ttUsers.ttfUserID = users.user_id
-            NO-ERROR.
-        IF NOT AVAIL ttUsers THEN DO:
-            CREATE ttUsers.
-            ASSIGN
-                ttUsers.ttfPdbName = PDBNAME(1)
-                ttUsers.ttfUserID = users.user_id
-                .
-/* 39245 - User MODE does not save - 12/10/18 - MYT - remove references to db-based fields; use .usr file only */
-/*            IF ttUsers.ttfModeList EQ "" THEN                                                                                */
-/*                ttUsers.ttfModeList = IF users.modeList GT "" THEN REPLACE(users.modeList, "|", ",") ELSE slModes:list-items.*/
-        END.
-        slModes:SCREEN-VALUE = IF ttUsers.ttfModeList NE "" THEN ttUsers.ttfModeList ELSE slModes:LIST-ITEMS.
-
         FIND _user NO-LOCK WHERE 
             _user._userid = users.user_id
             NO-ERROR.
-        IF AVAIL _user THEN
-        ASSIGN
+        IF AVAIL _user THEN ASSIGN
             fiPassword:SCREEN-VALUE = _user._password
-            cOldPwd = _user._password
-            .
+            cOldPwd = _user._password.
+        
         ASSIGN
-            bChgPwd:SENSITIVE = IF users.user_id = zusers.user_id OR zusers.securityLevel > 699 THEN TRUE ELSE FALSE
+            bChgPwd:SENSITIVE = IF users.user_id EQ zusers.user_id OR zusers.securityLevel GE 700 THEN TRUE ELSE FALSE
             fiPassword:SENSITIVE = FALSE
             .
+        
         IF users.userImage[1]:SCREEN-VALUE NE "" THEN 
-        cUserImage:LOAD-IMAGE(users.userImage[1]:SCREEN-VALUE).
+            cUserImage:LOAD-IMAGE(users.userImage[1]:SCREEN-VALUE).
         
     END.
     
@@ -2352,7 +2429,7 @@ PROCEDURE local-update-record :
                 usr.last-chg = today.
         END.
 
-        /* Most elements come from the 'generic' ttUser (ttfPdbname = '*') */
+        /* "Limit" elements come from the 'generic' ttUser (ttfPdbname = '*') */
         FIND ttUsers WHERE
             ttUsers.ttfPdbName = "*" AND
             ttUsers.ttfUserID = users.user_id:SCREEN-VALUE
@@ -2367,27 +2444,11 @@ PROCEDURE local-update-record :
             ttUsers.ttfUserAlias = users.userAlias:SCREEN-VALUE
             ttUsers.ttfEnvList = if slEnvironments:SCREEN-VALUE <> slEnvironments:list-items then slEnvironments:SCREEN-VALUE else ""
             ttUsers.ttfDbList = if slDatabases:SCREEN-VALUE <> slDatabases:list-items then slDatabases:SCREEN-VALUE else ""
-            ttUsers.ttfModeList = ""
+            ttUsers.ttfModeList = if slModes:SCREEN-VALUE <> slModes:list-items then slModes:SCREEN-VALUE else ""
             .
 
-        /* But mode-list has a by-db component (ttfPdbname = pdbname(1)) */
-        FIND ttUsers WHERE
-            ttUsers.ttfPdbName = PDBNAME(1) AND
-            ttUsers.ttfUserID = users.user_id:SCREEN-VALUE
-            NO-ERROR.
-        IF NOT AVAIL ttUsers THEN DO:
-            CREATE ttUsers.
-            ASSIGN
-                ttUsers.ttfPdbName = PDBNAME(1)
-                ttUsers.ttfUserID = users.user_id:SCREEN-VALUE.
-        END.
-        ASSIGN
-            ttUsers.ttfModeList = if slModes:SCREEN-VALUE <> slModes:list-items then slModes:SCREEN-VALUE else ""
-            ttUsers.ttfEnvList = ""
-            ttUsers.ttfDbList = ""
-            ttUsers.ttfUserAlias = ""
-            .
          ASSIGN iSecLevel = INTEGER(users.securityLevel:SCREEN-VALUE) . 
+
   /* Dispatch standard ADM method.                             */
   RUN dispatch IN THIS-PROCEDURE ( INPUT 'update-record':U ) .
 

--- a/Source/viewers/users.w
+++ b/Source/viewers/users.w
@@ -93,7 +93,7 @@ DEFINE TEMP-TABLE ttUsers
         
 DEFINE TEMP-TABLE ttModes
     FIELD ttfMode AS CHAR.
-            
+
 DEFINE BUFFER bttUsers FOR ttUsers.
 
 /* _UIB-CODE-BLOCK-END */
@@ -1712,7 +1712,7 @@ PROCEDURE ipCleanUsrFile:
         otherwise skip this user, because the streamline process has already been run for him/her */
         IF ttUsers.ttfPdbname EQ "*" THEN DO:                           /* Is this the master record? */
             
-            IF ttUsers.ttfModeList EQ "" THEN NEXT.                     /* SKIP user if the mode list been set at the master level already */
+            IF ttUsers.ttfModeList NE "" THEN NEXT.                     /* SKIP user if the mode list been set at the master level already */
             
             ELSE DO:  
                 /* Look for any "per-database" lines that have limits set (this is where modes USED to be controlled) */
@@ -1749,12 +1749,13 @@ PROCEDURE ipCleanUsrFile:
 
     /* Last, delete the "bad" ttUser records that contain per-database entries */
     /* This will be written back out to advantzware.usr in ipWriteUserFile */
-    FOR EACH ttUsers WHERE 
-        ttUsers.ttfPdbname NE "*":
-        DELETE ttUsers.
-        ASSIGN 
-            lCleaned = TRUE.
-    END.                        
+    /* DISABLE THIS UNTIL ALL USERS HAVE 21.02 OR HIGHER */
+/*    FOR EACH ttUsers WHERE        */
+/*        ttUsers.ttfPdbname NE "*":*/
+/*        DELETE ttUsers.           */
+/*        ASSIGN                    */
+/*            lCleaned = TRUE.      */
+/*    END.                          */
 
     /* If we cleaned the file and updated the ttUsers table, write advantzware.usr file with changes and re-read */
     IF lCleaned EQ TRUE THEN DO:

--- a/Source/viewers/users.w
+++ b/Source/viewers/users.w
@@ -1749,13 +1749,13 @@ PROCEDURE ipCleanUsrFile:
 
     /* Last, delete the "bad" ttUser records that contain per-database entries */
     /* This will be written back out to advantzware.usr in ipWriteUserFile */
-    /* DISABLE THIS UNTIL ALL USERS HAVE 21.02 OR HIGHER */
-/*    FOR EACH ttUsers WHERE        */
-/*        ttUsers.ttfPdbname NE "*":*/
-/*        DELETE ttUsers.           */
-/*        ASSIGN                    */
-/*            lCleaned = TRUE.      */
-/*    END.                          */
+    /* Note that this will NOT affect backward compatibility, as the display control is in the update asiLogin program */
+    FOR EACH ttUsers WHERE
+        ttUsers.ttfPdbname NE "*":
+        DELETE ttUsers.
+        ASSIGN
+            lCleaned = TRUE.
+    END.
 
     /* If we cleaned the file and updated the ttUsers table, write advantzware.usr file with changes and re-read */
     IF lCleaned EQ TRUE THEN DO:


### PR DESCRIPTION
Programs changed:
asiLogin.w
- ll 119,125   removed unneeded variables
- ll 528-535   ensure lookup of user finds the "master"
- l 1341          removed ability to update .usr file from login (moved to NU3)
- ll1370-1388 removed unneeded variables
- l 1425         removed .usr file update procedure
viewers/users.w
- l 94            added temp-table for use in sorting modes
- ll 1682-1769  cleanup routine for .usr file (see code for doc)
- ll 1829-18/33 detect bad lines in .usr file to determine if clean is needed
- ll 1846-1848   notes only, no logic
- l 2109          removed commented code
- ll 2119-2130  moved logic for mode list from "per-db" to "per-user"
- ll 2133-2144   cosmetic only
- ll 2144-2448  removed creation of "per-db" user records