### PR TITLE
100772 Fix use of cURL in NQ1 to prevent need for installation on ser…

### DIFF
--- a/Source/system/wUpdateHst.w
+++ b/Source/system/wUpdateHst.w
@@ -427,14 +427,14 @@ PROCEDURE ipInstallPatch:
     IF SEARCH("c:\tmp\hotfixlist.txt") NE ? THEN DO:
         INPUT FROM VALUE("c:\tmp\hotfixlist.txt").
         IMPORT UNFORMATTED cRawLine.
+        
         IF INDEX("0123456789",SUBSTRING(cRawLine,1,1)) EQ 0 THEN LEAVE.  /* cURL worked, but returned an error */
         SEARCH-BLOCK:
-        REPEAT:
+        DO:
             ASSIGN 
                 deNewVersion = DECIMAL(SUBSTRING(cRawLine,1,5)) 
                 iNewPatch = INTEGER(SUBSTRING(cRawLine,7,2)).             
-            IF deNewVersion LT deMyVersion THEN NEXT.
-            ELSE IF deNewVersion GT deMyVersion THEN DO:
+            IF deNewVersion GT deMyVersion THEN DO:
                 ASSIGN 
                     lCanUpgrade = TRUE.
                 /* Newer VERSION available */


### PR DESCRIPTION
…vers

program vchanged: system/wUpdateHist.w
l 37 - added variable to hold cURL location
ll 357-367 - find cURL executable; if can't find, disable button
l 422 use found cURL
ll 429-430 if curl reports an error, abort the import
l 458 move IMPORT to support the line 429 check
l 473 use found cURL
l 477 replicate the 7zip change made in 100463 to prevent merge conflict