### PR TITLE
100844 Error in dAOA - Invalid Entry with odd symbol

### DIFF
--- a/Deployment/BuildScript/ToCompile/asiUpdateEnv.w
+++ b/Deployment/BuildScript/ToCompile/asiUpdateEnv.w
@@ -5238,6 +5238,14 @@ PROCEDURE ipLoadDAOAData :
             emailConfig.configID = 1
             emailConfig.description = "DAOA Report Config".
     END.
+    
+/* 100844 Error in dAOA - Invalid Entry with odd symbol */
+    DISABLE TRIGGERS FOR LOAD OF dynValueParam.
+    FOR EACH dynValueParam EXCLUSIVE WHERE 
+        dynValueParam.paramvalue EQ CHR(231):
+        ASSIGN 
+            dynValueParam.paramvalue = CHR(254).
+    END.    
 
 END PROCEDURE.
 


### PR DESCRIPTION
program changed: asiUpdateENV.w
added block to ensure bad characters are corrected during upgrade