### PR TITLE
101652 Unable to print WIP tags after upgrade to 21.02

### DIFF
--- a/Source/Inventory/InventoryProcs.p
+++ b/Source/Inventory/InventoryProcs.p
@@ -4777,6 +4777,7 @@ PROCEDURE CreatePrintInventory:
      Notes: 
     ------------------------------------------------------------------------------*/
     DEFINE INPUT PARAMETER ipcInventoryStockID LIKE inventoryTransaction.inventoryStockID NO-UNDO.
+    DEFINE OUTPUT PARAMETER TABLE FOR ttPrintInventoryStock.
     
     DEFINE VARIABLE cCustName LIKE oe-ord.cust-name NO-UNDO.
     DEFINE VARIABLE cMachName LIKE mach.m-dscr      NO-UNDO.

--- a/Source/Inventory/InventoryProcs.p
+++ b/Source/Inventory/InventoryProcs.p
@@ -4777,7 +4777,7 @@ PROCEDURE CreatePrintInventory:
      Notes: 
     ------------------------------------------------------------------------------*/
     DEFINE INPUT PARAMETER ipcInventoryStockID LIKE inventoryTransaction.inventoryStockID NO-UNDO.
-    DEFINE OUTPUT PARAMETER TABLE FOR ttPrintInventoryStock.
+    DEFINE INPUT-OUTPUT PARAMETER TABLE FOR ttPrintInventoryStock.
     
     DEFINE VARIABLE cCustName LIKE oe-ord.cust-name NO-UNDO.
     DEFINE VARIABLE cMachName LIKE mach.m-dscr      NO-UNDO.

--- a/Source/wip/wip-create.w
+++ b/Source/wip/wip-create.w
@@ -786,7 +786,7 @@ DO:
     
             RUN CreatePrintInventory IN hdInventoryProcs (
                 INPUT ttBrowseInventory.inventoryStockID,
-                OUTPUT TABLE ttPrintInventoryStock 
+                INPUT-OUTPUT TABLE ttPrintInventoryStock 
                 ).
         END.
         
@@ -801,9 +801,10 @@ DO:
                     INPUT ttBrowseInventory.inventoryStockID
                     ).
         
+
             RUN CreatePrintInventory IN hdInventoryProcs (
                 INPUT ttBrowseInventory.inventoryStockID,
-                OUTPUT TABLE ttPrintInventoryStock
+                INPUT-OUTPUT TABLE ttPrintInventoryStock
                 ).
         
             RUN pPrintLabels.

--- a/Source/wip/wip-create.w
+++ b/Source/wip/wip-create.w
@@ -785,7 +785,8 @@ DO:
                     ).
     
             RUN CreatePrintInventory IN hdInventoryProcs (
-                INPUT ttBrowseInventory.inventoryStockID
+                INPUT ttBrowseInventory.inventoryStockID,
+                OUTPUT TABLE ttPrintInventoryStock 
                 ).
         END.
         
@@ -800,8 +801,9 @@ DO:
                     INPUT ttBrowseInventory.inventoryStockID
                     ).
         
-            RUN CreatePrintInventory in hdInventoryProcs (
-                INPUT ttBrowseInventory.inventoryStockID
+            RUN CreatePrintInventory IN hdInventoryProcs (
+                INPUT ttBrowseInventory.inventoryStockID,
+                OUTPUT TABLE ttPrintInventoryStock
                 ).
         
             RUN pPrintLabels.


### PR DESCRIPTION
Programs changed:
Inventory/InventoryProcs.p - make temp-table passed back to caller
wip/wip-create.w - make temp-table passed back to caller