### PR TITLE
102654 Error prompt in OB4 Posting

### DIFF
--- a/Source/oe/CloseOrder.p
+++ b/Source/oe/CloseOrder.p
@@ -81,6 +81,7 @@ IF NOT THIS-PROCEDURE:PERSISTENT THEN
         INPUT iplUpdate,
         OUTPUT opcStatus,
         OUTPUT opcReason).
+DELETE PROCEDURE hdOrderProcs.
 
 /* _UIB-CODE-BLOCK-END */
 &ANALYZE-RESUME


### PR DESCRIPTION
added line to delete orderProcs handle when procedure finishes
as it was, would create a new instance of orderProcs ( with 6 temp-tables per instance) for every order touched during invoicing