### PR TITLE
100278 Alternate method for identifying when using a feature branch i…

### DIFF
--- a/Source/system/mainMenu.w
+++ b/Source/system/mainMenu.w
@@ -1971,6 +1971,11 @@ PROCEDURE pInit :
     {&WINDOW-NAME}:TITLE = fTranslate({&WINDOW-NAME}:PRIVATE-DATA,NO) + " "
                          + DYNAMIC-FUNCTION("sfVersion")
                          .
+    
+    /* Ticket 100278 - will ONLY occur in Develop or Branch Test environment */
+    IF INDEX({&WINDOW-NAME}:TITLE,"99.99.99") NE 0 THEN ASSIGN 
+        {&WINDOW-NAME}:TITLE = "Advantzware QA System Testing: " + "{&awversion}".
+    
 
 END PROCEDURE.
 

--- a/Source/system/sysconst.i
+++ b/Source/system/sysconst.i
@@ -1,3 +1,4 @@
 /* WFK - 3/25/16 - Include to store constants for system programs */
 
 &Global-define EulaFile Eula.txt
+&Global-define awversion 99.99.99


### PR DESCRIPTION
…n testing

Programs changed:
system/mainmenu.w - added logic to display alternate title in Devel or Branch Test
system/sysconst.i - added awversion global scoped variable to hold branch ID