### PR TITLE
103537_EC-BOM_Cost_Not_Calculating_Correctly

### DIFF
--- a/Source/cec/box/pr42-mfl.p
+++ b/Source/cec/box/pr42-mfl.p
@@ -53,6 +53,8 @@ DEF VAR tot-c-m LIKE w-brd.cost-m NO-UNDO.
 DEF VAR ld-rm-rate AS DEC NO-UNDO.
 DEFINE VARIABLE dSetupCostQtyUOM  AS DECIMAL NO-UNDO.
 DEFINE VARIABLE dCostQtyUOM       AS DECIMAL NO-UNDO.
+DEFINE VARIABLE dBoardLength      AS DECIMAL NO-UNDO.
+DEFINE VARIABLE dBoardWidth       AS DECIMAL NO-UNDO.
 
 
 {cec/msfcalc.i}
@@ -96,11 +98,15 @@ do with no-box no-labels frame med1  stream-io :
 
    if xef.n-out-l eq 0 then
      assign
+      dBoardLength = brd-l[2]
+      dBoardWidth = brd-w[2] / (1 - (item-bom.shrink / 100))
       med-qty = brd-w[2] / (1 - (item-bom.shrink / 100))
       med-qty = if v-corr then ((med-qty * brd-l[2]) * mqty) * .000007
                           else ((med-qty * brd-l[2]) * mqty) / 144000.
    else
      assign
+      dBoardLength = brd-l[2] / (1 - (item-bom.shrink / 100))
+      dBoardWidth = brd-w[2]
       med-qty = brd-l[2] / (1 - (item-bom.shrink / 100))
       med-qty = if v-corr then ((med-qty * brd-w[2]) * mqty) * .000007
                           else ((med-qty * brd-w[2]) * mqty) / 144000.
@@ -110,6 +116,7 @@ do with no-box no-labels frame med1  stream-io :
     /* If Old vendor logic then apply the conversion. For new, conversion logic is in Vendor Cost proc */
     IF lNewVendorItemCost THEN
     DO:
+        
         RUN est/getVendorCostinQtyUOM.p(Item.company, 
             item.i-no, 
             "RM", 
@@ -119,6 +126,10 @@ do with no-box no-labels frame med1  stream-io :
             xeb.blank-no,
             med-qty,
             "MSF",
+            dBoardLength,
+            dBoardWidth,
+            0,
+            item.basis-w,
             OUTPUT dCostQtyUOM,
             OUTPUT dSetupCostQtyUOM,
             OUTPUT mfl$).

--- a/Source/cec/box/pr42-mfl.p
+++ b/Source/cec/box/pr42-mfl.p
@@ -250,7 +250,10 @@ do with no-box no-labels frame flute  stream-io :
       adh-qty[2] = 1
       med-qty = if v-corr then ((brd-l[2] * brd-w[2]) * tot-qty) * .000007
                        else ((brd-l[2] * brd-w[2]) * tot-qty) / 144000
-      fg-wt = fg-wt + (fg-qty * (if avail(item) then item.basis-w else 1)).
+      fg-wt = fg-wt + (fg-qty * (if avail(item) then item.basis-w else 1))
+      dBoardLength = brd-l[2]
+      dBoardWidth = brd-w[2]
+      .
 
     /* If Old vendor logic then apply the conversion. For new, conversion logic is in Vendor Cost proc */
     IF lNewVendorItemCost THEN
@@ -264,6 +267,10 @@ do with no-box no-labels frame flute  stream-io :
             xeb.blank-no,
             med-qty,
             "MSF",
+            dBoardLength,
+            dBoardWidth,
+            0,
+            item.basis-w,
             OUTPUT dCostQtyUOM,
             OUTPUT dSetupCostQtyUOM,
             OUTPUT mfl$).

--- a/Source/cec/pr4-spe.i
+++ b/Source/cec/pr4-spe.i
@@ -26,6 +26,10 @@ DEFINE VARIABLE dCostQtyUOM       AS DECIMAL NO-UNDO.
                  xeb.blank-no,
                  s-qty[i],
                  item.cons-uom,
+                 item.s-len, 
+                 item.s-wid, 
+                 item.s-dep,
+                 item.basis-w,
                  OUTPUT dCostQtyUOM,
                  OUTPUT dSetupCostQtyUOM,
                  OUTPUT s-cost[i]).         

--- a/Source/est/getVendorCostinQtyUOM.p
+++ b/Source/est/getVendorCostinQtyUOM.p
@@ -29,6 +29,10 @@ DEFINE INPUT  PARAMETER ipiFormNo           AS INTEGER   NO-UNDO.
 DEFINE INPUT  PARAMETER ipiBlankNo          AS INTEGER   NO-UNDO.
 DEFINE INPUT  PARAMETER ipdQty              AS DECIMAL NO-UNDO.
 DEFINE INPUT  PARAMETER ipcQtyUOM           AS CHARACTER NO-UNDO.
+DEFINE INPUT  PARAMETER ipdLength           AS DECIMAL NO-UNDO.
+DEFINE INPUT  PARAMETER ipdWidth            AS DECIMAL NO-UNDO.
+DEFINE INPUT  PARAMETER ipdDepth            AS DECIMAL NO-UNDO.
+DEFINE INPUT  PARAMETER ipdBasisWeight      AS DECIMAL NO-UNDO.
 DEFINE OUTPUT PARAMETER opdCostQtyUOM       AS DECIMAL NO-UNDO.
 DEFINE OUTPUT PARAMETER opdSetupCostQtyUOM  AS DECIMAL NO-UNDO.
 DEFINE OUTPUT PARAMETER opdCostTotal        AS DECIMAL NO-UNDO.
@@ -60,11 +64,11 @@ IF AVAILABLE bf-Item THEN
         ipiBlankNo,
         ipdQty, 
         ipcQtyUOM,
-        bf-Item.s-len, 
-        bf-Item.s-wid, 
-        bf-Item.s-dep, 
+        ipdLength,
+        ipdWidth,
+        ipdDepth,
         "IN", 
-        bf-Item.basis-w, 
+        ipdBasisWeight,
         "LB/EA", 
         NO,
         OUTPUT dCostPerUOM, 
@@ -87,11 +91,11 @@ IF cCostUOM NE ipcQtyUOM THEN
 DO:
         
     RUN pConvertCostFromUOMToUOM(ipcCompanyCode, ipcItemCode, ipcItemType, cCostUOM, ipcQtyUOM, 
-        bf-Item.basis-w, bf-Item.s-len, bf-Item.s-wid, bf-Item.s-dep, 
+        ipdBasisWeight, ipdLength, ipdWidth, ipdDepth, 
         dCostPerUOM, OUTPUT opdCostQtyUOM).
         
     RUN pConvertCostFromUOMToUOM(ipcCompanyCode, ipcItemCode, ipcItemType, cCostUOM, ipcQtyUOM, 
-        bf-Item.basis-w, bf-Item.s-len, bf-Item.s-wid, bf-Item.s-dep, 
+        ipdBasisWeight, ipdLength, ipdWidth, ipdDepth, 
         dCostSetup, OUTPUT opdSetupCostQtyUOM).
         
         

--- a/Source/est/getVendorCostinQtyUOM.p
+++ b/Source/est/getVendorCostinQtyUOM.p
@@ -95,7 +95,11 @@ DO:
         dCostSetup, OUTPUT opdSetupCostQtyUOM).
         
         
-END. 
+END.
+ELSE
+    ASSIGN
+        opdCostQtyUOM      = dCostPerUOM
+        opdSetupCostQtyUOM = dCostSetup. 
         
 
 


### PR DESCRIPTION
Fixed issue with BOM cost calculation. Updated the code to refer old cost tables like e-item when NK1 is not set. Used file est/getVendorCostinQtyUOM.p to calculate and return cost as per quantity UOM.
File: 
cec/box/pr42-mfl.p
est\getVendorCostinQtyUOM.p
Source/cec/pr4-spe.i