### PR TITLE
104320_MISC_Sub_Cost_Not_Pulling_Correctly

### DIFF
--- a/Source/VendorCostTester.p
+++ b/Source/VendorCostTester.p
@@ -397,13 +397,14 @@ PROCEDURE pGetBestCost PRIVATE:
     DEFINE VARIABLE dBestCostSetup      AS DECIMAL   NO-UNDO.
     DEFINE VARIABLE cBestVendorID       AS CHARACTER NO-UNDO.
     DEFINE VARIABLE dQuantity           AS DECIMAL   NO-UNDO INITIAL 10000.
+    DEFINE VARIABLE dBestCostTotal      AS DECIMAL NO-UNDO.
     
     cValidScopes = DYNAMIC-FUNCTION("VendCost_GetValidScopes","").
     cScope = ENTRY(iScopeEntry, cValidScopes).
     RUN VendCost_GetBestCost(ipcCompany, cItemID, cItemType, cScope, lIncludeBlankVendor,
         "",0,0, 
         dQuantity, "EA", dDimLength, dDimWidth, dDimDepth, "IN", dBasisWeight, "LBS/MSF",
-        OUTPUT dBestCostPerUOM, OUTPUT dBestCostSetup, OUTPUT cBestVendorID, OUTPUT lError, OUTPUT cMessage).
+        OUTPUT dBestCostPerUOM, OUTPUT dBestCostSetup, OUTPUT cBestVendorID, OUTPUT dBestCostTotal, OUTPUT lError, OUTPUT cMessage).
     MESSAGE "Best" SKIP  
         "Qty in MSF: " dDimLength * dDimWidth / 144000 * dQuantity SKIP 
         "Vendor: " cBestVendorID SKIP 

--- a/Source/cec/box/pr42-mfl.p
+++ b/Source/cec/box/pr42-mfl.p
@@ -405,7 +405,7 @@ if v-add-to-est AND
 
 
 
-      IF AVAIL e-item THEN
+      IF NOT lNewVendorItemCost AND AVAIL e-item THEN
       DO:
          EMPTY TEMP-TABLE tt-ei.
          CREATE tt-ei.
@@ -499,7 +499,7 @@ if v-add-to-est AND
 
       find first e-item of item no-lock no-error.
 
-      IF AVAIL e-item THEN
+      IF NOT lNewVendorItemCost AND AVAIL e-item THEN
       DO:
          EMPTY TEMP-TABLE tt-ei.
          CREATE tt-ei.

--- a/Source/cec/com/pr4-flm.p
+++ b/Source/cec/com/pr4-flm.p
@@ -83,7 +83,10 @@ for each est-flm
 
   RUN est/ef-#out.p (ROWID(bf-ef), OUTPUT v-n-out).
 
-  find first e-item of item no-lock no-error.
+  
+  RELEASE e-item.
+  IF NOT lNewVendorItemCost THEN
+    find first e-item of item no-lock no-error.
   fuom = if avail e-item then e-item.std-uom else item.cons-uom.
 
   find first bf-eb

--- a/Source/cec/pr4-cas.p
+++ b/Source/cec/pr4-cas.p
@@ -16,6 +16,14 @@ DEF BUFFER b-qty FOR reftable.
 DEF BUFFER b-cost FOR reftable.
 DEF BUFFER b-setup FOR reftable.
 
+DEFINE VARIABLE dSetupCostQtyUOM AS DECIMAL NO-UNDO.
+DEFINE VARIABLE dCostQtyUOM      AS DECIMAL NO-UNDO.
+DEFINE VARIABLE dSetupCost       AS DECIMAL NO-UNDO.
+DEFINE VARIABLE dDimLength       AS DECIMAL NO-UNDO.
+DEFINE VARIABLE dDimWidth        AS DECIMAL NO-UNDO.
+DEFINE VARIABLE dDimDepth        AS DECIMAL NO-UNDO.
+
+
 {cec/print4.i shared shared}
 {sys/inc/venditemcost.i}
 {cec/msfcalc.i}
@@ -44,13 +52,45 @@ find first ce-ctrl {sys/look/ce-ctrlW.i} no-lock no-error.
 
       if c-qty > int(c-qty) then c-qty = integer(c-qty) + 1.
       else c-qty = integer(c-qty).
-
+      
+       ASSIGN
+           dDimLength = IF xeb.cas-len NE 0 THEN xeb.cas-len ELSE item.case-l
+           dDimWidth  = IF xeb.cas-wid NE 0 THEN xeb.cas-wid ELSE item.case-w
+           dDimDepth  = IF xeb.cas-dep NE 0 THEN xeb.cas-dep ELSE item.case-d     
+           .
+           
       IF xeb.casNoCharge THEN c-cost = 0.
       ELSE IF xeb.cas-cost GT 0 THEN c-cost = xeb.cas-cost * c-qty.
       ELSE DO:
-        
-        {est/matcost.i c-qty c-cost case}
-        c-cost = (c-cost * c-qty) + lv-setup-case.        
+          IF lNewVendorItemCost THEN
+          DO:
+              RUN est/getVendorCostinQtyUOM.p(Item.company, 
+                  item.i-no, 
+                  "RM", 
+                  v-vend-no,
+                  xeb.est-no,
+                  xeb.form-no,
+                  xeb.blank-no,
+                  c-qty,
+                  "EA",
+                  dDimLength, 
+                  dDimWidth, 
+                  dDimDepth,
+                  item.basis-w,
+                  OUTPUT dCostQtyUOM,
+                  OUTPUT dSetupCostQtyUOM,
+                  OUTPUT c-cost).
+               
+              dSetupCost = dSetupCostQtyUOM. 
+                 
+          END.
+          ELSE
+          DO:
+              {est/matcost.i c-qty c-cost case}
+              c-cost = (c-cost * c-qty) + lv-setup-case. 
+              dSetupCost = lv-setup-case.
+          END.
+              
       END.
 
       ASSIGN
@@ -81,7 +121,7 @@ find first ce-ctrl {sys/look/ce-ctrlW.i} no-lock no-error.
               xeb.cas-cnt format ">>>>9" "Pieces/Pack"
               (qty / c-qty) when xeb.cas-cnt eq 0 @ xeb.cas-cnt
               c-qty format ">>>>>9" to 48 "Bdl"
-              lv-setup-case when lv-setup-case ne 0 format ">>>9.99" to 59
+              dSetupCost when dSetupCost ne 0 format ">>>9.99" to 59
               c-cost / (save-qty / 1000) / v-sqft-fac format ">>>>9.99" to 68
               c-cost format ">>>>,>>9.99" to 80 skip with stream-io.
 
@@ -103,13 +143,46 @@ find first ce-ctrl {sys/look/ce-ctrlW.i} no-lock no-error.
 
       if p-qty > integer(p-qty) then p-qty = integer(p-qty) + 1.
       else p-qty = integer(p-qty).
-
+    
+        ASSIGN
+           dDimLength = IF xeb.tr-len NE 0 THEN xeb.tr-len ELSE item.case-l
+           dDimWidth  = IF xeb.tr-wid NE 0 THEN xeb.tr-wid ELSE item.case-w
+           dDimDepth  = IF xeb.tr-dep NE 0 THEN xeb.tr-dep ELSE item.case-d     
+           dSetupCost = 0
+           .
+      
       IF xeb.trNoCharge THEN p-cost = 0.
       ELSE IF xeb.tr-cost GT 0 THEN p-cost = xeb.tr-cost * p-qty.
       
-      ELSE DO:           
-        {est/matcost.i p-qty p-cost pallet}
-        p-cost = (p-cost * p-qty) + lv-setup-pallet.        
+      ELSE DO: 
+          IF lNewVendorItemCost THEN
+          DO:
+              RUN est/getVendorCostinQtyUOM.p(Item.company, 
+                  item.i-no, 
+                  "RM", 
+                  v-vend-no,
+                  xeb.est-no,
+                  xeb.form-no,
+                  xeb.blank-no,
+                  p-qty,
+                  "EA",
+                  dDimLength, 
+                  dDimWidth, 
+                  dDimDepth,
+                  item.basis-w,
+                  OUTPUT dCostQtyUOM,
+                  OUTPUT dSetupCostQtyUOM,
+                  OUTPUT p-cost).
+               
+              dSetupCost = dSetupCostQtyUOM. 
+          END.
+          ELSE
+          DO:       
+              {est/matcost.i p-qty p-cost pallet}
+              p-cost = (p-cost * p-qty) + lv-setup-pallet.
+              dSetupCost = lv-setup-pallet. 
+          END.
+               
       END.
 
       ASSIGN
@@ -139,12 +212,19 @@ find first ce-ctrl {sys/look/ce-ctrlW.i} no-lock no-error.
       if p-qty ne 0 then pallet-blok: do.
          display item.i-name when avail(item)
                  p-qty format ">>>>>9" to 48 "Ea."
-                 lv-setup-pallet when lv-setup-pallet ne 0 format ">>>9.99" to 59
+                 dSetupCost when dSetupCost ne 0 format ">>>9.99" to 59
                  p-cost / (save-qty / 1000) / v-sqft-fac format ">>>>9.99" to 68
                  p-cost format ">>>>,>>9.99" to 80 skip with stream-io.
 
          {cec/pr4-str.i}
 
+         ASSIGN
+           dDimLength = item.case-l
+           dDimWidth  = item.case-w
+           dDimDepth  = item.case-d     
+           dSetupCost = 0
+           .
+         
          if strap-qty ne 0 then do:
             strap-qty = strap-qty * p-qty / 1000.
 
@@ -155,13 +235,39 @@ find first ce-ctrl {sys/look/ce-ctrlW.i} no-lock no-error.
 
             if not avail item then leave pallet-blok.
             
-            {est/matcost.i strap-qty strap-cst strap}
-            strap-cst = (strap-cst * strap-qty) + lv-setup-strap.
+             IF lNewVendorItemCost THEN
+             DO:
+                 RUN est/getVendorCostinQtyUOM.p(Item.company, 
+                     item.i-no, 
+                     "RM", 
+                     v-vend-no,
+                     xeb.est-no,
+                     xeb.form-no,
+                     xeb.blank-no,
+                     strap-qty,
+                     "MLI",
+                     dDimLength, 
+                     dDimWidth, 
+                     dDimDepth,
+                     item.basis-w,
+                     OUTPUT dCostQtyUOM,
+                     OUTPUT dSetupCostQtyUOM,
+                     OUTPUT strap-cst).
+               
+                 dSetupCost = dSetupCostQtyUOM. 
+             END.
+             ELSE
+             DO:
+                   
+                 {est/matcost.i strap-qty strap-cst strap}
+                 strap-cst = (strap-cst * strap-qty) + lv-setup-strap.
+                 dSetupCost = lv-setup-strap.
+             END.
             
             if strap-qty ne 0 then do with frame ac4 no-box no-labels:
                display item.i-name
                        strap-qty format ">>>,>>>"                 to 48 "MLI"
-                       lv-setup-strap when lv-setup-strap ne 0 format ">>>9.99" to 59
+                       dSetupCost when dSetupCost ne 0 format ">>>9.99" to 59
                        strap-cst / (save-qty / 1000) / v-sqft-fac format ">>>>9.99" to 68
                        strap-cst format ">>>>>>>9.99" to 80 skip
                    with stream-io.

--- a/Source/cec/pr4-spe.i
+++ b/Source/cec/pr4-spe.i
@@ -15,7 +15,7 @@ DEFINE VARIABLE dCostQtyUOM       AS DECIMAL NO-UNDO.
          
          /* If Old vendor logic then apply this conversion. For new, conversion logic is in Vendor Cost proc */
          RELEASE e-item.
-         IF lNewVendorItemCost AND v-vend-no NE "" THEN
+         IF lNewVendorItemCost THEN
          DO:
              RUN est/getVendorCostinQtyUOM.p(Item.company, 
                  item.i-no, 

--- a/Source/est/EstimateCalcProcs.p
+++ b/Source/est/EstimateCalcProcs.p
@@ -4543,7 +4543,7 @@ PROCEDURE pGetEstFarmCosts PRIVATE:
             ipdQty, ipcQtyUOM, 
             ipbf-estCostMaterial.dimLength, ipbf-estCostMaterial.dimWidth, ipbf-estCostMaterial.dimDepth, ipbf-estCostMaterial.dimUOM, 
             ipbf-estCostMaterial.basisWeight, ipbf-estCostMaterial.basisWeightUOM,
-            OUTPUT opdCost, OUTPUT opcCostUOM, OUTPUT opdSetup, OUTPUT opcVendorID, OUTPUT opdCostDeviation,
+            OUTPUT opdCost, OUTPUT opcCostUOM, OUTPUT opdSetup, OUTPUT opcVendorID, OUTPUT opdCostDeviation, OUTPUT dCostTotal,
             OUTPUT lError, OUTPUT cMessage).
     END.
     ELSE 
@@ -4681,7 +4681,7 @@ PROCEDURE pGetEstMaterialCosts PRIVATE:
                     ipdQty, ipcQtyUOM, 
                     ipbf-estCostMaterial.dimLength, ipbf-estCostMaterial.dimWidth, ipbf-estCostMaterial.dimDepth, ipbf-estCostMaterial.dimUOM, 
                     ipbf-estCostMaterial.basisWeight, ipbf-estCostMaterial.basisWeightUOM,
-                    OUTPUT opdCost, OUTPUT opcCostUOM, OUTPUT opdSetup, OUTPUT opcVendorID, OUTPUT opdCostDeviation,
+                    OUTPUT opdCost, OUTPUT opcCostUOM, OUTPUT opdSetup, OUTPUT opcVendorID, OUTPUT opdCostDeviation, OUTPUT dCostTotal,
                     OUTPUT lError, OUTPUT cMessage).
          END.
 

--- a/Source/system/VendorCostProcs.p
+++ b/Source/system/VendorCostProcs.p
@@ -2598,6 +2598,7 @@ PROCEDURE VendCost_GetBestCost:
     DEFINE OUTPUT PARAMETER opdBestCostSetup AS DECIMAL NO-UNDO.
     DEFINE OUTPUT PARAMETER opcBestCostVendorID AS CHARACTER NO-UNDO.
     DEFINE OUTPUT PARAMETER opdBestCostDeviation AS DECIMAL NO-UNDO.
+    DEFINE OUTPUT PARAMETER opdBestCostTotal AS DECIMAL NO-UNDO.
     DEFINE OUTPUT PARAMETER oplError AS LOGICAL NO-UNDO.
     DEFINE OUTPUT PARAMETER opcMessage AS CHARACTER NO-UNDO.
 
@@ -2620,6 +2621,7 @@ PROCEDURE VendCost_GetBestCost:
             opcBestCostVendorID  = ttVendItemCost.vendorID 
             opcBestCostVendorUOM = ttVendItemCost.vendorUOM
             opdBestCostDeviation = ttVendItemCost.costDeviation
+            opdBestCostTotal     = ttVendItemCost.costTotal
             .
         LEAVE.
     END. 
@@ -2635,6 +2637,7 @@ PROCEDURE VendCost_GetBestCost:
                 opcBestCostVendorID  = ttVendItemCost.vendorID 
                 opcBestCostVendorUOM = ttVendItemCost.vendorUOM
                 opdBestCostDeviation = ttVendItemCost.costDeviation
+                opdBestCostTotal     = ttVendItemCost.costTotal
                 .
             LEAVE.
         END.         


### PR DESCRIPTION
Fixed issue with special material cost in case of Blank vendor. Added fallback logic in legacy estimating.
Files:
Source/VendorCostTester.p
Source/cec/pr4-spe.i
Source/est/EstimateCalcProcs.p
Source/est/getVendorCostinQtyUOM.p
Source/system/VendorCostProcs.p
Source/VendorCostTester.p 
