### PR TITLE
106628 Update legacy edi templates to use 6 digit PO numbers for send PO

### DIFF
--- a/Source/po/po-acpi.i
+++ b/Source/po/po-acpi.i
@@ -35,7 +35,7 @@ PUT
 
     "<R4><C50><#3>" SKIP
     "<FArial><P14><=#3>" /*<C-20><R-2> <B>Purchase Order</B>*/  "<P10>" SKIP
-    "<=#3><R+1><B><P12>PO #: " po-ord.po-no format '99999999' "</B><P10>" SKIP(1)
+    "<=#3><R+1><B><P12>PO #: " po-ord.po-no format '999999' "</B><P10>" SKIP(1)
     "<=#3><R+2>Date: " po-ord.po-date        SKIP
     "<=#3><R+3>Changed Date: " po-ord.po-change-date SKIP
     "<=3><R+4>Date Required: " po-ord.due-date SKIP.

--- a/Source/po/po-alnceexp.i
+++ b/Source/po/po-alnceexp.i
@@ -320,7 +320,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
     PUT "01"                                        FORMAT "x(2)".
     
     /* PURCHASE ORDER # */
-    PUT po-ord.po-no                                FORMAT "99999999".
+    PUT po-ord.po-no                                FORMAT "999999".
 
     /* A */
     PUT "A"                                         FORMAT "x(1)".
@@ -329,7 +329,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
     PUT po-ordl.line                                FORMAT "99".
     
     /* PURCHASE ORDER # */
-    PUT po-ord.po-no                                FORMAT "99999999".
+    PUT po-ord.po-no                                FORMAT "999999".
 
     /* A */
     PUT "A"                                         FORMAT "x(1)".

--- a/Source/po/po-alnceexp1.i
+++ b/Source/po/po-alnceexp1.i
@@ -319,7 +319,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
     PUT "01"                                        FORMAT "x(2)".
     
     /* PURCHASE ORDER # */
-    PUT po-ord.po-no                                FORMAT "99999999".
+    PUT po-ord.po-no                                FORMAT "999999".
 
     /* A */
     PUT "A"                                         FORMAT "x(1)".
@@ -328,7 +328,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
     PUT po-ordl.line                                FORMAT "99".
     
     /* PURCHASE ORDER # */
-    PUT po-ord.po-no                                FORMAT "99999999".
+    PUT po-ord.po-no                                FORMAT "999999".
 
     /* A */
     PUT "A"                                         FORMAT "x(1)".

--- a/Source/po/po-ccexp.i
+++ b/Source/po/po-ccexp.i
@@ -291,7 +291,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
     PUT "01"                                        FORMAT "x(2)".
     
     /* PURCHASE ORDER # */
-    PUT po-ord.po-no                                FORMAT "99999999".
+    PUT po-ord.po-no                                FORMAT "999999".
 
     /* A */
     PUT "A"                                         FORMAT "x(1)".
@@ -300,7 +300,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
     PUT po-ordl.line                                FORMAT "99".
     
     /* PURCHASE ORDER # */
-    PUT po-ord.po-no                                FORMAT "99999999".
+    PUT po-ord.po-no                                FORMAT "999999".
 
     /* A */
     PUT "A"                                         FORMAT "x(1)".

--- a/Source/po/po-ccexp.p
+++ b/Source/po/po-ccexp.p
@@ -291,7 +291,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
     put "01"                                        format "x(2)".
     
     /* PURCHASE ORDER # */
-    put po-ord.po-no                                format "99999999".
+    put po-ord.po-no                                format "999999".
 
     /* A */
     put "A"                                         format "x(1)".
@@ -300,7 +300,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
     put po-ordl.line                                format "99".
     
     /* PURCHASE ORDER # */
-    put po-ord.po-no                                format "99999999".
+    put po-ord.po-no                                format "999999".
 
     /* A */
     put "A"                                         format "x(1)".

--- a/Source/po/po-csexp.p
+++ b/Source/po/po-csexp.p
@@ -288,7 +288,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
     put "01"                                        format "x(2)".
     
     /* PURCHASE ORDER # */
-    put po-ord.po-no                                format "99999999".
+    put po-ord.po-no                                format "999999".
 
     /* A */
     put "A"                                         format "x(1)".
@@ -297,7 +297,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
     put po-ordl.line                                format "99".
     
     /* PURCHASE ORDER # */
-    put po-ord.po-no                                format "99999999".
+    put po-ord.po-no                                format "999999".
 
     /* A */
     put "A"                                         format "x(1)".

--- a/Source/po/po-hrexp.p
+++ b/Source/po/po-hrexp.p
@@ -505,10 +505,10 @@ FOR EACH report NO-LOCK WHERE
         PUT 
             cAssignedCustId     FORMAT "x(5)"       /* CUSTOMER # */
             "01"                FORMAT "x(2)"       /* 01 */
-            po-ord.po-no        FORMAT "99999999"     /* PURCHASE ORDER # */
+            po-ord.po-no        FORMAT "999999"     /* PURCHASE ORDER # */
             "A"                 FORMAT "x(1)"       /* A */
             po-ordl.line        FORMAT "99"         /* PURCHASE ORDER # */
-            po-ord.po-no        FORMAT "99999999"     /* PURCHASE ORDER # */
+            po-ord.po-no        FORMAT "999999"     /* PURCHASE ORDER # */
             "A"                 FORMAT "x(1)"       /* A */
             po-ordl.line        FORMAT "99"         /* PURCHASE ORDER # */
             FILL(" ",2)         FORMAT "xx"         /* MESSAGE CODE #1 */

--- a/Source/po/po-ipaper.p
+++ b/Source/po/po-ipaper.p
@@ -317,7 +317,7 @@ IF AVAILABLE cust AND iPaper-log AND iPaper-dir NE "" THEN
             PUT "01"                                        FORMAT "x(2)".
     
             /* PURCHASE ORDER # */
-            PUT po-ord.po-no                                FORMAT "99999999".
+            PUT po-ord.po-no                                FORMAT "999999".
 
             /* A */
             PUT "A"                                         FORMAT "x(1)".
@@ -326,7 +326,7 @@ IF AVAILABLE cust AND iPaper-log AND iPaper-dir NE "" THEN
             PUT po-ordl.line                                FORMAT "99".
     
             /* PURCHASE ORDER # */
-            PUT po-ord.po-no                                FORMAT "99999999".
+            PUT po-ord.po-no                                FORMAT "999999".
 
             /* A */
             PUT "A"                                         FORMAT "x(1)".

--- a/Source/po/po-ktexp.p
+++ b/Source/po/po-ktexp.p
@@ -267,13 +267,13 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
     PUT "01"                                        FORMAT "x(2)".
     
     /* PURCHASE ORDER # */
-    PUT po-ord.po-no                                FORMAT "99999999".
+    PUT po-ord.po-no                                FORMAT "999999".
     
     /* PURCHASE ORDER LINE # */
     PUT po-ordl.line                                FORMAT "99".
     
     /* PURCHASE ORDER # */
-    PUT po-ord.po-no                                FORMAT "99999999".
+    PUT po-ord.po-no                                FORMAT "999999".
     
     /* PURCHASE ORDER LINE # */
     PUT po-ordl.line                                FORMAT "99".
@@ -709,7 +709,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
       IF po-ordl.job-no EQ "" THEN v-job-no = "".
 
       IF v-job-no EQ "-" THEN v-job-no = "".
-      v-desc-no = STRING(po-ordl.po-no,"99999999") + "-" + STRING(po-ordl.LINE,"99") + "/" + v-job-no + "-" + STRING(po-ordl.s-num,"99") . 
+      v-desc-no = STRING(po-ordl.po-no,"999999") + "-" + STRING(po-ordl.LINE,"99") + "/" + v-job-no + "-" + STRING(po-ordl.s-num,"99") . 
     END.
 
     PUT v-desc-no                                   FORMAT "x(21)".

--- a/Source/po/po-kwexp.p
+++ b/Source/po/po-kwexp.p
@@ -240,13 +240,13 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
     PUT "01"                                        FORMAT "x(2)".
     
     /* PURCHASE ORDER # */
-    PUT po-ord.po-no                                FORMAT "99999999".
+    PUT po-ord.po-no                                FORMAT "999999".
     
     /* PURCHASE ORDER LINE # */
     PUT po-ordl.line                                FORMAT "99".
     
     /* PURCHASE ORDER # */
-    PUT po-ord.po-no                                FORMAT "99999999".
+    PUT po-ord.po-no                                FORMAT "999999".
     
     /* PURCHASE ORDER LINE # */
     PUT po-ordl.line                                FORMAT "99".

--- a/Source/po/po-librt.p
+++ b/Source/po/po-librt.p
@@ -249,7 +249,7 @@ IF AVAILABLE cust AND liberty-log AND liberty-dir NE "" THEN
         fInsText("L",   357,   25, "NW"            ). /* po status */
         fInsText("L",   383,   25, "N"             ). /* po type */
         fInsText("L",   409,    6, "AMC"           ). /* sheet plant abbreviation */
-        fInsText("L",   416,   22, STRING(po-ord.po-no, "99999999")).
+        fInsText("L",   416,   22, STRING(po-ord.po-no, "999999")).
         fInsText("L",   439,   10, STRING(po-ord.po-date, "99/99/9999")).
         fInsText("L",   450,    1, "T"             ). /* process stat */
         fInsText("L",   452,   10, STRING(po-ord.due-date, "99/99/9999")).
@@ -716,7 +716,7 @@ IF AVAILABLE cust AND liberty-log AND liberty-dir NE "" THEN
             fInsText("R",   525,   11, STRING(v-ord-qty[1]) ).
             fInsText("L",   537,    9, STRING(po-ordl.ord-no) ). /* Order # for associated sales ord */
             fInsText("L",   547,    6, "AMC"         ). /* sheet plant abbreviation */
-            fInsText("L",   554,   22,  STRING(po-ordl.po-no, "99999999")).
+            fInsText("L",   554,   22,  STRING(po-ordl.po-no, "999999")).
             fInsText("L",   577,   30, ""         ). /* not used */
             fInsText("L",   608,    2, SUBSTRING(po-ordl.pr-uom, 1, 2)       ). /* Price UOM, Take the MS from MSF  */
             fInsText("L",   611,   30, ""         ). /* not used */
@@ -755,7 +755,7 @@ IF AVAILABLE cust AND liberty-log AND liberty-dir NE "" THEN
             fInsText("L",  360, 10, v-adder[6]    ). /* 6th board adder */
             fInsText("L",  371, 10, v-adder[7]    ). /* 7th board adder */
             fInsText("L",  382, 10, ""            ). /* 8th board adder */    
-            fInsText("L",  393, 22, STRING(po-ord.po-no, "99999999") ). /* po # */
+            fInsText("L",  393, 22, STRING(po-ord.po-no, "999999") ). /* po # */
             fInsText("L",  416, 11, STRING(po-ordl.line) ). /* po line # */
             fInsText("L",  428, 10, "0"        ). /* combo msf 3 decimals */
             fInsText("L",  439, 11, STRING(po-ordl.ord-qty - (po-ord.under-pct * po-ordl.ord-qty / 100)    )). /* PO min qty */

--- a/Source/po/po-prexp.p
+++ b/Source/po/po-prexp.p
@@ -317,7 +317,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
     put "01"                                        format "x(2)".
     
     /* PURCHASE ORDER # */
-    put po-ord.po-no                                format "99999999".
+    put po-ord.po-no                                format "999999".
 
     /* A */
     put "A"                                         format "x(1)".
@@ -326,7 +326,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
     put po-ordl.line                                format "99".
     
     /* PURCHASE ORDER # */
-    put po-ord.po-no                                format "99999999".
+    put po-ord.po-no                                format "999999".
 
     /* A */
     put "A"                                         format "x(1)".

--- a/Source/po/po-smurfi.p
+++ b/Source/po/po-smurfi.p
@@ -333,7 +333,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
     put "01"                                        format "x(2)".
     
     /* PURCHASE ORDER # */
-    put po-ord.po-no                                format "99999999".
+    put po-ord.po-no                                format "999999".
 
     /* A */
     put "A"                                         format "x(1)".
@@ -342,7 +342,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
     put po-ordl.line                                format "99".
     
     /* PURCHASE ORDER # */
-    put po-ord.po-no                                format "99999999".
+    put po-ord.po-no                                format "999999".
 
     /* A */
     put "A"                                         format "x(1)".


### PR DESCRIPTION
Files
1. po\po-alnceexp1.i
2. po\po-acpi.i
3. po\po-alnceexp.i
4. po\po-ccexp.i
5. po\po-ccexp.p
6. po\po-csexp.p
7. po\po-hrexp.p
8. po\po-ipaper.p
9. po\po-ktexp.p
10. po\po-kwexp.p
11. po\po-librt.p
12. po\po-prexp.p
13. po\po-smurfi.p