### PR TITLE
102014_Combo_or_set_estimates_short_grain_sheet_routing

### DIFF
--- a/Source/ce/box/mach-seq.p
+++ b/Source/ce/box/mach-seq.p
@@ -695,9 +695,10 @@ for each xef
     end.
   end.
 
+/* Commented this becase Die Size (trim-l and trim-w) should *never* be used directly in the machine limit determination
   assign
    sh-len = xef.trim-w
-   sh-wid = xef.trim-l.
+   sh-wid = xef.trim-l.*/
 
   /* get die cutter */
   diecut:

--- a/Source/ce/com/mach-seq.p
+++ b/Source/ce/com/mach-seq.p
@@ -564,9 +564,11 @@ for each xef where xef.company = xest.company
     end.
   end.
 
+ /* Commented this becase Die Size (trim-l and trim-w) should *never* be used directly in the machine limit determination
   assign
    sh-len = xef.trim-w
-   sh-wid = xef.trim-l.
+   sh-wid = xef.trim-l.*/
+
 
   /* get die cutter */
   diecut:

--- a/Source/ce/mach-seq.p
+++ b/Source/ce/mach-seq.p
@@ -673,10 +673,11 @@ do on error undo:
   end.
 end.
 
+/* Commented this becase Die Size (trim-l and trim-w) should *never* be used directly in the machine limit determination
 IF xef.n-out-l GT 1 THEN
   assign
    sh-len = xef.trim-w
-   sh-wid = xef.trim-l.
+   sh-wid = xef.trim-l.*/
 
 /* get die cutter */
 diecut:

--- a/Source/ce/tan/mach-seq.p
+++ b/Source/ce/tan/mach-seq.p
@@ -555,9 +555,10 @@ do on error undo:
   end.
 end.
 
+/* Commented this becase Die Size (trim-l and trim-w) should *never* be used directly in the machine limit determination
 assign
  sh-len = xef.trim-w
- sh-wid = xef.trim-l.
+ sh-wid = xef.trim-l.*/
 
 /* laminating */
 if xef.medium ne "" or xef.flute ne "" or xef.lam-code ne "" then


### PR DESCRIPTION
Updated the Routings logic so that Die Size (trim-l and trim-w) should *never* be used directly in the machine limit determination.  It is only a measurement that helps to build the machine feed (nsh-len, nsh-wid) which is what should be used for machine limits on Sheet fed operations.