### PR TITLE
110054 Regression: NS8 APSecure No Longer Working with NK6 APPosting UserID

### DIFF
--- a/Source/ap/r-apve&pN.w
+++ b/Source/ap/r-apve&pN.w
@@ -879,7 +879,7 @@ DO ON ERROR   UNDO MAIN-BLOCK, LEAVE MAIN-BLOCK
         ASSIGN
              begin_user:SCREEN-VALUE = USERID("ASI")
              end_user:SCREEN-VALUE   = USERID("ASI").
-        IF cAPPostingUserId EQ "No" THEN
+        IF cAPPostingUserId EQ "No" AND NOT lAPSecure THEN
            ASSIGN
                begin_user:SENSITIVE    = NO
                end_user:SENSITIVE      = NO .


### PR DESCRIPTION
Please review this change and merge into development branch 
Files - Source/ap/r-apve&pN.w