### PR TITLE
107865-Adding-a-estimate-run-quantity-to-an-estimate-causes-incorrect…

### DIFF
--- a/Source/est/EstimateCalcProcs.p
+++ b/Source/est/EstimateCalcProcs.p
@@ -2089,8 +2089,9 @@ PROCEDURE pBuildHeadersToProcess PRIVATE:
     DO:
         FIND FIRST bf-est-qty
             WHERE bf-est-qty.company EQ bf-est.company
-            AND bf-est-qty.est-no  EQ bf-est.est-no
-            NO-LOCK NO-ERROR.
+              AND bf-est-qty.est-no  EQ bf-est.est-no
+              AND bf-est-qty.qty[1]  NE 0
+             NO-LOCK NO-ERROR.
         IF AVAILABLE bf-est-qty THEN 
             DO iQtyCount = 1 TO 20:
 


### PR DESCRIPTION
…-quantity-use-on-calc

Description:
Added condition for est-qty.qty[1] NE 0 for selection of master quantity.
Files:
est/EstimateCalcProcs.p