### PR TITLE
106302-E-C-Layout-Tab-Number-Out-not-Transferring-to-Routing-Tab-Numb…

### DIFF
--- a/Source/est/d-estop.w
+++ b/Source/est/d-estop.w
@@ -1954,7 +1954,7 @@ PROCEDURE valid-mach :
                     IF lv-dept EQ "RC" THEN STRING(xef.n-out) ELSE STRING(xef.n-out-l).  */            
 
 
-        IF AVAILABLE xef AND (adm-adding-record OR INTEGER(est-op.n-out:SCREEN-VALUE ) EQ 0) THEN
+        IF AVAILABLE xef THEN
         DO:
             RUN Operations_GetNumout IN hdOpProcs ( INPUT xef.company,
                 INPUT xef.est-no,


### PR DESCRIPTION
…er-Out

Description:
The value for n-out in prep/rout tab on choose of import button are getting updated only if est-op.n-out:screen-value is 0. Changed this condition so that n-out gets updated also when est-op.n-out:screen-value is not 0.

Files:
est/d-estop.w