### PR TITLE
111887 Unable to Print AP Checks since new Version Installed

### DIFF
--- a/Source/ap/CheckPrintDefs.i
+++ b/Source/ap/CheckPrintDefs.i
@@ -153,7 +153,7 @@ DEFINE {1} TEMP-TABLE ttCheckConfig LIKE ttcheckconfig1
  FIELD checkRemitToNameRightJustify AS LOG
  FIELD checkRemitToNameAllCaps AS LOG INIT YES
 
- FIELD checkRemitToAddNameShow AS LOG INIT YES
+ FIELD checkRemitToAddNameShow AS LOG INIT NO
  FIELD checkRemitToAddNameFont AS CHAR 
  FIELD checkRemitToAddNameFontSize AS INT 
  FIELD checkRemitToAddNameSize AS INT INIT 70

--- a/Source/ap/reconcilrpt.p
+++ b/Source/ap/reconcilrpt.p
@@ -46,6 +46,16 @@ FOR EACH ap-pay NO-LOCK
           AND ap-ledger.refnum   EQ v-refnum
           AND ap-ledger.ref-date EQ ap-pay.check-date
         USE-INDEX ap-ledger NO-ERROR.
+    IF NOT AVAIL ap-ledger THEN DO:
+        v-refnum = "AC" + STRING(ap-pay.check-no, "99999999").
+    
+        FIND FIRST ap-ledger NO-LOCK
+            WHERE ap-ledger.company  EQ ap-pay.company
+              AND ap-ledger.vend-no  EQ ap-pay.vend-no
+              AND ap-ledger.refnum   EQ v-refnum
+              AND ap-ledger.ref-date EQ ap-pay.check-date
+            USE-INDEX ap-ledger NO-ERROR.
+    END.    
 
     IF NOT AVAIL ap-ledger THEN
     DO:
@@ -111,6 +121,17 @@ FOR EACH ap-pay NO-LOCK
           AND ap-ledger.refnum   EQ v-refnum
           AND ap-ledger.ref-date EQ ap-pay.check-date
         USE-INDEX ap-ledger NO-ERROR.
+        
+    IF NOT AVAIL ap-ledger THEN DO:
+        v-refnum = "AC" + STRING(ap-pay.check-no, "99999999").
+    
+        FIND FIRST ap-ledger NO-LOCK
+            WHERE ap-ledger.company  EQ ap-pay.company
+              AND ap-ledger.vend-no  EQ ap-pay.vend-no
+              AND ap-ledger.refnum   EQ v-refnum
+              AND ap-ledger.ref-date EQ ap-pay.check-date
+            USE-INDEX ap-ledger NO-ERROR.
+    END.    
 
     IF NOT AVAIL ap-ledger THEN
     DO:


### PR DESCRIPTION
Programs changed:
ap/CheckPrintDefs.i - ensure checkRemitToAddNameShow is initialized as False (do not display)
ap/reconcilrpt.p - ensure 6 and 8 digit check numbers are supported in Check Reconciliation report