### PR TITLE
107413 E-C Box Design Tab, ARROWS Keys showing Invalid

### DIFF
--- a/Source/ce/v-boxdee.w
+++ b/Source/ce/v-boxdee.w
@@ -1058,9 +1058,10 @@ PROCEDURE local-display-fields :
       ELSE if ll-is-3d-displayed AND
               box-design-hdr.box-3d-image <> "" then do:
               /*  box-image:auto-resize = yes. */
+             ASSIGN box-design-hdr.box-text:HIDDEN = YES
+                box-image-2:HIDDEN             = NO .
               IF INDEX(box-design-hdr.box-3d-image,".pdf") <= 0 THEN
                  ll-dummy = box-image-2:load-image(box-design-hdr.box-3d-image) in frame {&frame-name}.
-              ELSE box-image-2:HIDDEN = yes.
       end.
       ELSE DO:
           ASSIGN box-design-hdr.box-text:HIDDEN = NO

--- a/Source/cec/v-boxdee.w
+++ b/Source/cec/v-boxdee.w
@@ -1342,6 +1342,8 @@ PROCEDURE local-display-fields :
               box-design-hdr.box-3d-image <> "" THEN DO:
               /*  box-image:auto-resize = yes. */
               ll-dummy = box-image-2:load-image(box-design-hdr.box-3d-image) IN FRAME {&frame-name} NO-ERROR.
+             ASSIGN box-design-hdr.box-text:HIDDEN = YES
+                box-image-2:HIDDEN             = NO .
               /*assign box-image:height-pixels = box-image:height-pixels - 10
                 box-image:width-pixels =  box-image:width-pixels - 10.            
               */


### PR DESCRIPTION
This is only an issue when using the nav buttons to move through three-d images and one is encountered where the image is blank or not on file. Program changed:
cec/v-boxdee.w
ce/v-boxdee.w