### PR TITLE
113215 Length scores not showing on PO

### DIFF
--- a/Source/api/PrintPurchaseOrder.p
+++ b/Source/api/PrintPurchaseOrder.p
@@ -318,6 +318,7 @@ ELSE DO:
                 INPUT  po-ordl.company,
                 INPUT  po-ordl.po-no,
                 INPUT  po-ordl.line,
+                INPUT  "",
                 OUTPUT dScoreSize,
                 OUTPUT cScoreType
                 ).

--- a/Source/api/SendPurchaseOrder.p
+++ b/Source/api/SendPurchaseOrder.p
@@ -637,6 +637,7 @@ FUNCTION pSortVendItemNumbersAdders RETURNS CHARACTER PRIVATE
                 INPUT  po-ordl.company,
                 INPUT  po-ordl.po-no,
                 INPUT  po-ordl.line,
+                INPUT  "",
                 OUTPUT dScoreSizeArray,
                 OUTPUT cScoreTypeArray
                 ).

--- a/Source/cecrep/jobloy.p
+++ b/Source/cecrep/jobloy.p
@@ -317,6 +317,7 @@ do v-local-loop = 1 to v-local-copies:
             INPUT  po-ordl.company,
             INPUT  po-ordl.po-no,
             INPUT  po-ordl.line,
+            INPUT  "",
             OUTPUT lv-val,
             OUTPUT lv-typ
             ).

--- a/Source/po/POProcs.p
+++ b/Source/po/POProcs.p
@@ -329,6 +329,7 @@ PROCEDURE PO_GetLineScoresAndTypes:
     DEFINE INPUT  PARAMETER ipcCompany    AS CHARACTER NO-UNDO.
     DEFINE INPUT  PARAMETER ipiPoID       AS INTEGER   NO-UNDO.
     DEFINE INPUT  PARAMETER ipiPoLine     AS INTEGER   NO-UNDO.
+    DEFINE INPUT  PARAMETER ipcPanelType  AS CHARACTER NO-UNDO.
     DEFINE OUTPUT PARAMETER opdScores     AS DECIMAL   NO-UNDO EXTENT 20.
     DEFINE OUTPUT PARAMETER opcScoreTypes AS CHARACTER NO-UNDO EXTENT 20.
     
@@ -361,7 +362,9 @@ PROCEDURE PO_GetLineScoresAndTypes:
         OUTPUT cReverseGrain,
         OUTPUT iEstimateType
         ).
-    
+    IF ipcPanelType NE "" THEN
+    cPanelType = ipcPanelType.
+    ELSE
     cPanelType = IF (cReverseGrain EQ "S" AND iEstimateType GE 5) OR cReverseGrain EQ "B" THEN
                      "L"
                  ELSE

--- a/Source/po/po-alexp.p
+++ b/Source/po/po-alexp.p
@@ -300,6 +300,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
         INPUT  po-ordl.company,
         INPUT  po-ordl.po-no,
         INPUT  po-ordl.line,
+        INPUT  "",
         OUTPUT lv-val,
         OUTPUT lv-typ
         ).

--- a/Source/po/po-alnceexp.i
+++ b/Source/po/po-alnceexp.i
@@ -399,6 +399,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
         INPUT  po-ordl.company,
         INPUT  po-ordl.po-no,
         INPUT  po-ordl.line,
+        INPUT  "",
         OUTPUT lv-val,
         OUTPUT lv-typ
         ).

--- a/Source/po/po-alnceexp1.i
+++ b/Source/po/po-alnceexp1.i
@@ -398,6 +398,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
         INPUT  po-ordl.company,
         INPUT  po-ordl.po-no,
         INPUT  po-ordl.line,
+        INPUT  "",
         OUTPUT lv-val,
         OUTPUT lv-typ
         ).

--- a/Source/po/po-capcity.p
+++ b/Source/po/po-capcity.p
@@ -674,6 +674,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
             INPUT  po-ordl.company,
             INPUT  po-ordl.po-no,
             INPUT  po-ordl.line,
+            INPUT  "",
             OUTPUT lv-val,
             OUTPUT lv-typ
             ).

--- a/Source/po/po-ccexp.i
+++ b/Source/po/po-ccexp.i
@@ -370,6 +370,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
         INPUT  po-ordl.company,
         INPUT  po-ordl.po-no,
         INPUT  po-ordl.line,
+        INPUT  "",
         OUTPUT lv-val,
         OUTPUT lv-typ
         ).

--- a/Source/po/po-ccexp.p
+++ b/Source/po/po-ccexp.p
@@ -370,6 +370,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
         INPUT  po-ordl.company,
         INPUT  po-ordl.po-no,
         INPUT  po-ordl.line,
+        INPUT  "",
         OUTPUT lv-val,
         OUTPUT lv-typ
         ).

--- a/Source/po/po-ckexp.p
+++ b/Source/po/po-ckexp.p
@@ -318,6 +318,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
         INPUT  po-ordl.company,
         INPUT  po-ordl.po-no,
         INPUT  po-ordl.line,
+        INPUT  "",
         OUTPUT lv-val,
         OUTPUT lv-typ
         ).

--- a/Source/po/po-csexp.p
+++ b/Source/po/po-csexp.p
@@ -397,6 +397,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
         INPUT  po-ordl.company,
         INPUT  po-ordl.po-no,
         INPUT  po-ordl.line,
+        INPUT  "",
         OUTPUT lv-val,
         OUTPUT lv-typ
         ).

--- a/Source/po/po-ctexp.p
+++ b/Source/po/po-ctexp.p
@@ -557,6 +557,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
         INPUT  po-ordl.company,
         INPUT  po-ordl.po-no,
         INPUT  po-ordl.line,
+        INPUT  "",
         OUTPUT lv-val,
         OUTPUT lv-typ
         ).

--- a/Source/po/po-gpexp.p
+++ b/Source/po/po-gpexp.p
@@ -383,6 +383,7 @@ IF gp-log AND gp-dir NE "" THEN
                 INPUT  po-ordl.company,
                 INPUT  po-ordl.po-no,
                 INPUT  po-ordl.line,
+                INPUT  "",
                 OUTPUT lv-val,
                 OUTPUT lv-typ
                 ).

--- a/Source/po/po-hrexp.p
+++ b/Source/po/po-hrexp.p
@@ -305,6 +305,7 @@ FOR EACH report NO-LOCK WHERE
             INPUT  po-ordl.company,
             INPUT  po-ordl.po-no,
             INPUT  po-ordl.line,
+            INPUT  "",
             OUTPUT lv-val,
             OUTPUT lv-typ
             ).

--- a/Source/po/po-ipaper.p
+++ b/Source/po/po-ipaper.p
@@ -396,6 +396,7 @@ IF AVAILABLE cust AND iPaper-log AND iPaper-dir NE "" THEN
                 INPUT  po-ordl.company,
                 INPUT  po-ordl.po-no,
                 INPUT  po-ordl.line,
+                INPUT  "",
                 OUTPUT lv-val,
                 OUTPUT lv-typ
                 ).

--- a/Source/po/po-ktexp.p
+++ b/Source/po/po-ktexp.p
@@ -332,6 +332,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
         INPUT  po-ordl.company,
         INPUT  po-ordl.po-no,
         INPUT  po-ordl.line,
+        INPUT  "",
         OUTPUT lv-val,
         OUTPUT lv-typ
         ).

--- a/Source/po/po-kwexp.p
+++ b/Source/po/po-kwexp.p
@@ -305,6 +305,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
         INPUT  po-ordl.company,
         INPUT  po-ordl.po-no,
         INPUT  po-ordl.line,
+        INPUT  "",
         OUTPUT lv-val,
         OUTPUT lv-typ
         ).

--- a/Source/po/po-librt.p
+++ b/Source/po/po-librt.p
@@ -381,6 +381,7 @@ IF AVAILABLE cust AND liberty-log AND liberty-dir NE "" THEN
                 INPUT  po-ordl.company,
                 INPUT  po-ordl.po-no,
                 INPUT  po-ordl.line,
+                INPUT  "",
                 OUTPUT lv-val,
                 OUTPUT lv-typ
                 ).

--- a/Source/po/po-prexp.p
+++ b/Source/po/po-prexp.p
@@ -396,6 +396,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
         INPUT  po-ordl.company,
         INPUT  po-ordl.po-no,
         INPUT  po-ordl.line,
+        INPUT  "",
         OUTPUT lv-val,
         OUTPUT lv-typ
         ).

--- a/Source/po/po-print.i
+++ b/Source/po/po-print.i
@@ -47,6 +47,11 @@ DEFINE {1} SHARED VARIABLE lPrintGrandTotMsf AS LOGICAL NO-UNDO.
 DEF VAR lv-val LIKE reftable.val EXTENT 20 NO-UNDO.
 DEF VAR lv-typ LIKE reftable.dscr EXTENT 20 NO-UNDO.
 DEF VAR lv-int AS INT NO-UNDO.
+DEFINE VARIABLE cScorePanelType AS CHARACTER NO-UNDO.
+DEFINE VARIABLE cWidScore AS CHARACTER NO-UNDO.
+DEFINE VARIABLE cWidScoreValue LIKE reftable.val EXTENT 20 NO-UNDO.
+DEFINE VARIABLE cWidScoreType LIKE reftable.dscr EXTENT 20 NO-UNDO.
+DEFINE VARIABLE clscoreWidth AS CHARACTER NO-UNDO.
 
 def var v-last-page         as   int.
 def var v-page-tot          as   int.

--- a/Source/po/po-protg.p
+++ b/Source/po/po-protg.p
@@ -583,41 +583,38 @@ find first company where company.company eq cocode NO-LOCK.
        assign
           v-line-number = v-line-number + 1
           v-printline = v-printline + 1
-          len-score = "".
-
+          len-score = ""
+          cWidScore = ""
+          cScorePanelType = "L".
        
        {po/poprints.i}       
        IF AVAIL ITEM AND lookup(ITEM.mat-type,"1,2,3,4") > 0 THEN DO: 
        END.
-       ELSE DO:
-          if not v-test-scr then do:
-             IF po-ordl.spare-char-1 = "LENGTH" THEN
-             put 
-                 "HOR Score: " AT 3
-                 len-score format "x(80)" SKIP .
-             ELSE
+       ELSE DO:           
+             IF len-score NE "" AND po-ordl.spare-char-1 = "LENGTH" THEN do:
+                 put 
+                     "HOR Score: " AT 3
+                     len-score format "x(80)" SKIP .
+                 ASSIGN
+                     v-line-number = v-line-number + 1
+                     v-printline = v-printline + 1.
+             END.    
+             ELSE IF len-score NE "" THEN do:
+                 PUT "Score: " AT 3
+                 len-score format "x(80)" SKIP . 
+                 ASSIGN
+                     v-line-number = v-line-number + 1
+                     v-printline = v-printline + 1.
+             END.    
+             IF  cWidScore NE "" THEN do:
                  put 
                      "Score: " AT 3
-                     len-score format "x(80)" SKIP .
-                 
-             ASSIGN
-             v-line-number = v-line-number + 1
-             v-printline = v-printline + 1.
-          end.
-       
-          else
-          if dec(trim(len-score)) ne v-wid then do:
-              IF po-ordl.spare-char-1 = "LENGTH" THEN
-                  put "HOR Score: " AT 3
-                      len-score format "x(80)"  SKIP.
-              ELSE
-                  put "Score: " AT 3
-                      len-score format "x(80)"  SKIP.
-                 
-             ASSIGN
-             v-line-number = v-line-number + 1
-             v-printline = v-printline + 1.
-          END.
+                     cWidScore format "x(80)" SKIP .
+                     
+                 ASSIGN
+                      v-line-number = v-line-number + 1
+                      v-printline = v-printline + 1. 
+             END.
        END.
          end.
          END.

--- a/Source/po/po-protg2.p
+++ b/Source/po/po-protg2.p
@@ -594,41 +594,37 @@ find first company where company.company eq cocode NO-LOCK.
        assign
           v-line-number = v-line-number + 1
           v-printline = v-printline + 1
-          len-score = "".
+          len-score = ""
+          cScorePanelType = "L".
 
        
        {po/poprints.i}       
        IF AVAIL ITEM AND lookup(ITEM.mat-type,"1,2,3,4") > 0 THEN DO: 
        END.
        ELSE DO:
-          if not v-test-scr then do:
-             IF po-ordl.spare-char-1 = "LENGTH" THEN
-             put 
-                 "HOR Score: " AT 3
-                 len-score format "x(80)" SKIP .
-             ELSE
+          IF len-score NE "" AND po-ordl.spare-char-1 = "LENGTH" THEN do:
+                 put 
+                     "HOR Score: " AT 3
+                     len-score format "x(80)" SKIP .
+                 ASSIGN
+                     v-line-number = v-line-number + 1
+                     v-printline = v-printline + 1.
+             END.    
+             ELSE IF len-score NE "" THEN do:
+                 PUT "Score: " AT 3
+                 len-score format "x(80)" SKIP . 
+                 ASSIGN
+                     v-line-number = v-line-number + 1
+                     v-printline = v-printline + 1.
+             END.    
+             IF  cWidScore NE "" THEN do:
                  put 
                      "Score: " AT 3
-                     len-score format "x(80)" SKIP .
-                 
-             ASSIGN
-             v-line-number = v-line-number + 1
-             v-printline = v-printline + 1.
-          end.
-       
-          else
-          if dec(trim(len-score)) ne v-wid then do:
-              IF po-ordl.spare-char-1 = "LENGTH" THEN
-                  put "HOR Score: " AT 3
-                      len-score format "x(80)"  SKIP.
-              ELSE
-                  put "Score: " AT 3
-                      len-score format "x(80)"  SKIP.
-                 
-             ASSIGN
-             v-line-number = v-line-number + 1
-             v-printline = v-printline + 1.
-          END.
+                     cWidScore format "x(80)" SKIP .                     
+                 ASSIGN
+                      v-line-number = v-line-number + 1
+                      v-printline = v-printline + 1. 
+             END.
        END.
          end.
          END.

--- a/Source/po/po-scexp.p
+++ b/Source/po/po-scexp.p
@@ -316,6 +316,7 @@ FOR EACH report NO-LOCK WHERE report.term-id EQ v-term-id,
         INPUT  po-ordl.company,
         INPUT  po-ordl.po-no,
         INPUT  po-ordl.line,
+        INPUT  "",
         OUTPUT lv-val,
         OUTPUT lv-typ
         ).

--- a/Source/po/po-smurfi.p
+++ b/Source/po/po-smurfi.p
@@ -442,6 +442,7 @@ FOR EACH report WHERE report.term-id EQ v-term-id NO-LOCK,
         INPUT  po-ordl.company,
         INPUT  po-ordl.po-no,
         INPUT  po-ordl.line,
+        INPUT  "",
         OUTPUT lv-val,
         OUTPUT lv-typ
         ).

--- a/Source/po/po-xprnt.p
+++ b/Source/po/po-xprnt.p
@@ -604,44 +604,50 @@ v-printline = 0.
 
         assign v-line-number = v-line-number + 1
                v-printline = v-printline + 1
-               len-score = "".
-
-        
+               len-score = ""
+               cScorePanelType = "L".        
 
         {po/poprints.i}
             IF NOT po-ordl.item-type THEN         
             IF AVAIL itemfg AND v-score-types THEN DO:
-                put 
-                    "Score: " AT 3
-                    len-score format "x(80)" SKIP .
-                
-                ASSIGN
-                    v-line-number = v-line-number + 1
-                    v-printline = v-printline + 1.
+                IF len-score NE "" THEN do:
+                    put 
+                        "Score: " AT 3
+                        len-score format "x(80)" SKIP .
+                    
+                    ASSIGN
+                        v-line-number = v-line-number + 1
+                        v-printline = v-printline + 1.
+                END. 
+                IF cWidScore NE "" THEN do:
+                    put 
+                        "Score: " AT 3
+                        cWidScore format "x(80)" SKIP .
+                    
+                    ASSIGN
+                        v-line-number = v-line-number + 1
+                        v-printline = v-printline + 1.
+                END.                     
             END.
 
             IF AVAIL ITEM AND lookup("1,2,3,4",ITEM.mat-type) > 0 THEN DO: 
             END.
             ELSE DO:
-               if not v-test-scr AND (AVAIL ITEM AND ITEM.mat-type = "B") then do:
-                  put 
-                      "Score: " AT 3
-                      len-score format "x(80)" SKIP .
-                      
-                  ASSIGN
-                  v-line-number = v-line-number + 1
-                  v-printline = v-printline + 1.
-               end.
-          
-               else
-               if v-test-scr AND AVAIL ITEM AND ITEM.mat-type = "B" AND dec(trim(len-score)) ne v-wid then do:
-                  put "Score: " AT 3
-                      len-score format "x(80)"  SKIP.
-                      
-                  ASSIGN
-                  v-line-number = v-line-number + 1
-                  v-printline = v-printline + 1.
-               END.
+               IF len-score NE "" AND AVAIL ITEM AND ITEM.mat-type = "B" THEN do:
+                 PUT "Score: " AT 3
+                 len-score format "x(80)" SKIP . 
+                 ASSIGN
+                     v-line-number = v-line-number + 1
+                     v-printline = v-printline + 1.
+             END.    
+             IF  cWidScore NE "" AND AVAIL ITEM AND ITEM.mat-type = "B" AND dec(trim(cWidScore)) ne v-wid THEN do:
+                 put 
+                     "Score: " AT 3
+                     cWidScore format "x(80)" SKIP .                     
+                 ASSIGN
+                      v-line-number = v-line-number + 1
+                      v-printline = v-printline + 1. 
+             END.
             END.
            end.
            END.

--- a/Source/po/po-xprnt.p
+++ b/Source/po/po-xprnt.p
@@ -640,7 +640,7 @@ v-printline = 0.
                      v-line-number = v-line-number + 1
                      v-printline = v-printline + 1.
              END.    
-             IF  cWidScore NE "" AND AVAIL ITEM AND ITEM.mat-type = "B" AND dec(trim(cWidScore)) ne v-wid THEN do:
+             IF  cWidScore NE "" AND AVAIL ITEM AND ITEM.mat-type = "B" THEN do:
                  put 
                      "Score: " AT 3
                      cWidScore format "x(80)" SKIP .                     

--- a/Source/po/po-xprnt10.p
+++ b/Source/po/po-xprnt10.p
@@ -701,7 +701,7 @@ v-printline = 0.
                      v-line-number = v-line-number + 1
                      v-printline = v-printline + 1.
              END.    
-             IF  cWidScore NE "" AND AVAIL ITEM AND ITEM.mat-type = "B" AND dec(trim(cWidScore)) ne v-wid THEN do:
+             IF  cWidScore NE "" AND AVAIL ITEM AND ITEM.mat-type = "B" THEN do:
                  put 
                      "Score: " AT 3
                      cWidScore format "x(80)" SKIP .                     

--- a/Source/po/po-xprnt10.p
+++ b/Source/po/po-xprnt10.p
@@ -664,44 +664,51 @@ v-printline = 0.
         
         assign v-line-number = v-line-number + 1
                v-printline = v-printline + 1
-               len-score = "".
-
+               len-score = ""
+               cScorePanelType = "L".
         
 
         {po/poprints.i}
             IF NOT po-ordl.item-type THEN         
             IF AVAIL itemfg AND v-score-types THEN DO:
-                put 
-                    "Score: " AT 3
-                    len-score format "x(80)" SKIP .
-                
-                ASSIGN
-                    v-line-number = v-line-number + 1
-                    v-printline = v-printline + 1.
+               IF len-score NE "" THEN do:
+                    put 
+                        "Score: " AT 3
+                        len-score format "x(80)" SKIP .
+                    
+                    ASSIGN
+                        v-line-number = v-line-number + 1
+                        v-printline = v-printline + 1.
+                END. 
+                IF cWidScore NE "" THEN do:
+                    put 
+                        "Score: " AT 3
+                        cWidScore format "x(80)" SKIP .
+                    
+                    ASSIGN
+                        v-line-number = v-line-number + 1
+                        v-printline = v-printline + 1.
+                END. 
             END.
 
             IF AVAIL ITEM AND lookup("1,2,3,4",ITEM.mat-type) > 0 THEN DO: 
             END.
             ELSE DO:
-               if not v-test-scr AND (AVAIL ITEM AND ITEM.mat-type = "B") then do:
-                  put 
-                      "Score: " AT 3
-                      len-score format "x(80)" SKIP .
-                      
-                  ASSIGN
-                  v-line-number = v-line-number + 1
-                  v-printline = v-printline + 1.
-               end.
-          
-               else
-               if v-test-scr AND AVAIL ITEM AND ITEM.mat-type = "B" AND dec(trim(len-score)) ne v-wid then do:
-                  put "Score: " AT 3
-                      len-score format "x(80)"  SKIP.
-                      
-                  ASSIGN
-                  v-line-number = v-line-number + 1
-                  v-printline = v-printline + 1.
-               END.
+               IF len-score NE "" AND AVAIL ITEM AND ITEM.mat-type = "B" THEN do:
+                 PUT "Score: " AT 3
+                 len-score format "x(80)" SKIP . 
+                 ASSIGN
+                     v-line-number = v-line-number + 1
+                     v-printline = v-printline + 1.
+             END.    
+             IF  cWidScore NE "" AND AVAIL ITEM AND ITEM.mat-type = "B" AND dec(trim(cWidScore)) ne v-wid THEN do:
+                 put 
+                     "Score: " AT 3
+                     cWidScore format "x(80)" SKIP .                     
+                 ASSIGN
+                      v-line-number = v-line-number + 1
+                      v-printline = v-printline + 1. 
+             END.
             END.
            end.
            END.


### PR DESCRIPTION
Please review this change and merge into development branch 
Files - Source/api/PrintPurchaseOrder.p
Source/api/SendPurchaseOrder.p
Source/cecrep/jobloy.p
Source/po/po-alexp.p
Source/po/po-alnceexp.i
Source/po/po-alnceexp1.i
Source/po/po-capcity.p
Source/po/po-ccexp.i
Source/po/po-ccexp.p
Source/po/po-ckexp.p
Source/po/po-csexp.p
Source/po/po-ctexp.p
Source/po/po-gpexp.p
Source/po/po-hrexp.p
Source/po/po-ipaper.p
Source/po/po-ktexp.p
Source/po/po-kwexp.p
Source/po/po-librt.p
Source/po/po-prexp.p
Source/po/po-print.i
Source/po/poprints.i
Source/po/POProcs.p
Source/po/po-protg.p
Source/po/po-protg2.p
Source/po/po-scexp.p
Source/po/po-smurfi.p
Source/po/po-xprnt.p
Source/po/po-xprnt10.p