### PR TITLE
111460 Unable to locate lmprint program in LM 2021

### DIFF
--- a/Source/custom/lmprint.p
+++ b/Source/custom/lmprint.p
@@ -199,6 +199,17 @@ PROCEDURE pGetExecutionPath:
 ------------------------------------------------------------------------------*/
 DEFINE OUTPUT PARAMETER opcPath AS CHARACTER NO-UNDO.
 
+/* This handles LM 2021 executables since location is not easily found in registry */
+ASSIGN 
+    opcPath = "'c:\program files\LABEL MATRIX 2021\lmwprint.exe'".
+IF SEARCH(opcPath) NE ? THEN RETURN.
+ELSE DO:
+    ASSIGN 
+        opcPath = "'c:\program files (x86)\LABEL MATRIX 2021\lmwprint.exe'".
+    IF SEARCH(opcPath) NE ? THEN RETURN.
+END.
+/* end of LM 2021 search */
+    
 RUN custom/getregvalue.p (INPUT "HKEY_LOCAL_MACHINE", 
                           INPUT "SOFTWARE",
                           INPUT "Teklynx\Label Matrix",


### PR DESCRIPTION
program changed: custom/lmprint.p
Note: This is NOT testable in any ASI environment; Laurel to determine whether to send as override