### PR TITLE
110656 PU1 - not bringing in the Vend Item # to PO Line from the vendor cost matrix

### DIFF
--- a/Source/VendorCostTester.p
+++ b/Source/VendorCostTester.p
@@ -435,6 +435,7 @@ PROCEDURE pPOVendCostCalc PRIVATE:
 
     DEFINE VARIABLE lError      AS LOGICAL   NO-UNDO.
     DEFINE VARIABLE cMessage    AS CHARACTER NO-UNDO.
+    DEFINE VARIABLE cVendorItemID    AS CHARACTER NO-UNDO.
 
     iPO# = 105207.
     
@@ -484,6 +485,7 @@ PROCEDURE pPOVendCostCalc PRIVATE:
                 OUTPUT dCostSetup, 
                 OUTPUT cCostUOM,
                 OUTPUT dCostTotal, 
+                OUTPUT cVendorItemID,
                 OUTPUT lError, 
                 OUTPUT cMessage).  
               
@@ -527,6 +529,7 @@ PROCEDURE pPOVendCostCalc PRIVATE:
                 OUTPUT dCostSetup, 
                 OUTPUT cCostUOM,
                 OUTPUT dCostTotal, 
+                OUTPUT cVendorItemID,
                 OUTPUT lError, 
                 OUTPUT cMessage).  
         END.
@@ -673,7 +676,8 @@ PROCEDURE pTestSampleFG PRIVATE:
 
     DEFINE VARIABLE lError      AS LOGICAL   NO-UNDO.
     DEFINE VARIABLE cMessage    AS CHARACTER NO-UNDO.
-
+    DEFINE VARIABLE cVendorItemID AS CHARACTER NO-UNDO.
+    
     FIND FIRST itemfg NO-LOCK 
         WHERE itemfg.company EQ gcCompany
         AND itemfg.i-no EQ "ZOVPURCH"
@@ -710,7 +714,8 @@ PROCEDURE pTestSampleFG PRIVATE:
         OUTPUT dCostPerUOM, 
         OUTPUT dCostSetup, 
         OUTPUT cCostUOM,
-        OUTPUT dCostTotal, 
+        OUTPUT dCostTotal,
+        OUTPUT cVendorItemID,
         OUTPUT lError, 
         OUTPUT cMessage).  
         
@@ -737,6 +742,7 @@ PROCEDURE pTestSampleRM PRIVATE:
 
     DEFINE VARIABLE lError      AS LOGICAL   NO-UNDO.
     DEFINE VARIABLE cMessage    AS CHARACTER NO-UNDO.
+    DEFINE VARIABLE cVendorItemID AS CHARACTER NO-UNDO.
 
     FIND FIRST item NO-LOCK 
         WHERE item.company EQ gcCompany
@@ -774,6 +780,7 @@ PROCEDURE pTestSampleRM PRIVATE:
         OUTPUT dCostSetup, 
         OUTPUT cCostUOM,
         OUTPUT dCostTotal, 
+        OUTPUT cVendorItemID,
         OUTPUT lError, 
         OUTPUT cMessage).  
         

--- a/Source/est/EstimateCalcProcs.p
+++ b/Source/est/EstimateCalcProcs.p
@@ -5827,7 +5827,7 @@ PROCEDURE pGetEstMaterialCosts PRIVATE:
     DEFINE VARIABLE lError              AS LOGICAL   NO-UNDO.
     DEFINE VARIABLE cMessage            AS CHARACTER NO-UNDO.
     DEFINE VARIABLE lUseBlank           AS LOGICAL   NO-UNDO.
-
+    DEFINE VARIABLE cVendorItemID       AS CHARACTER NO-UNDO.
 
     ASSIGN
         lCostFound = NO
@@ -5849,7 +5849,7 @@ PROCEDURE pGetEstMaterialCosts PRIVATE:
                 ipbf-ttEstCostMaterial.dimLength, ipbf-ttEstCostMaterial.dimWidth, ipbf-ttEstCostMaterial.dimDepth, ipbf-ttEstCostMaterial.dimUOM, 
                 ipbf-ttEstCostMaterial.basisWeight, ipbf-ttEstCostMaterial.basisWeightUOM, 
                 NO,
-                OUTPUT opdCost, OUTPUT opdSetup, OUTPUT opcCostUOM, OUTPUT dCostTotal, OUTPUT lError, OUTPUT cMessage).
+                OUTPUT opdCost, OUTPUT opdSetup, OUTPUT opcCostUOM, OUTPUT dCostTotal, OUTPUT cVendorItemID, OUTPUT lError, OUTPUT cMessage).
         END.
         ELSE 
         DO:                        

--- a/Source/est/RecostBoardEst.p
+++ b/Source/est/RecostBoardEst.p
@@ -68,7 +68,8 @@ PROCEDURE pGetNewCosts PRIVATE:
     DEFINE VARIABLE dCostSetup  AS DECIMAL   NO-UNDO.
     DEFINE VARIABLE dCostTotal  AS DECIMAL   NO-UNDO.
     DEFINE VARIABLE cCostUOM    AS CHARACTER NO-UNDO.    
-    DEFINE VARIABLE lError      AS LOGICAL   NO-UNDO.    
+    DEFINE VARIABLE lError      AS LOGICAL   NO-UNDO.
+    DEFINE VARIABLE cVendorItemID  AS CHARACTER NO-UNDO.
     
     FOR EACH ttRecostBoardGroups 
         WHERE ttRecostBoardGroups.Multi:
@@ -93,7 +94,8 @@ PROCEDURE pGetNewCosts PRIVATE:
             OUTPUT dCostPerUOM, 
             OUTPUT dCostSetup, 
             OUTPUT cCostUOM,
-            OUTPUT dCostTotal, 
+            OUTPUT dCostTotal,
+            OUTPUT cVendorItemID,
             OUTPUT oploError, 
             OUTPUT opchMessage).
 

--- a/Source/est/getVendCost.i
+++ b/Source/est/getVendCost.i
@@ -21,6 +21,7 @@ DEFINE VARIABLE cCostUOM{3}    AS CHARACTER NO-UNDO.
 
 DEFINE VARIABLE lError{3}      AS LOGICAL   NO-UNDO.
 DEFINE VARIABLE cMessage{3}    AS CHARACTER NO-UNDO.
+DEFINE VARIABLE cVendorItemID{3} AS CHARACTER NO-UNDO.
 /*DEF VAR lv-setup-{3} LIKE e-item-vend.setup NO-UNDO.*/
 
 /* ********************  Preprocessor Definitions  ******************** */
@@ -57,6 +58,7 @@ RUN GetVendorCost(vendItemCost.company,
     OUTPUT dCostSetup{3}, 
     OUTPUT cCostUOM{3},
     OUTPUT dCostTotal{3}, 
+    OUTPUT cVendorItemID{3},
     OUTPUT lError{3}, 
     OUTPUT cMessage{3}).  
     

--- a/Source/est/getVendorCostinQtyUOM.p
+++ b/Source/est/getVendorCostinQtyUOM.p
@@ -48,7 +48,7 @@ DEFINE VARIABLE cMessage    AS CHARACTER NO-UNDO.
 DEFINE VARIABLE cVendorID   AS CHARACTER NO-UNDO.
 DEFINE VARIABLE dCostDeviation AS DECIMAL NO-UNDO.
 DEFINE VARIABLE cScope         AS CHARACTER NO-UNDO.
-
+DEFINE VARIABLE cVendorItemID  AS CHARACTER NO-UNDO.
 
 DEFINE BUFFER bf-Item FOR Item.
 
@@ -79,7 +79,8 @@ DO:
             OUTPUT dCostPerUOM, 
             OUTPUT dCostSetup, 
             OUTPUT cCostUOM,
-            OUTPUT dCostTotal, 
+            OUTPUT dCostTotal,
+            OUTPUT cVendorItemID,
             OUTPUT lError, 
             OUTPUT cMessage).
             

--- a/Source/jc/b-jobfarm.w
+++ b/Source/jc/b-jobfarm.w
@@ -70,6 +70,7 @@ DEFINE VARIABLE dCostSetup  AS DECIMAL   NO-UNDO.
 DEFINE VARIABLE cCostUOM    AS CHARACTER NO-UNDO.
 DEFINE VARIABLE lError      AS LOGICAL   NO-UNDO.
 DEFINE VARIABLE cMessage    AS CHARACTER NO-UNDO.
+DEFINE VARIABLE cVendorItemID AS CHARACTER NO-UNDO.
 
 DEF BUFFER b-setup FOR reftable.
 
@@ -1479,6 +1480,7 @@ PROCEDURE new-i-no PRIVATE :
                 OUTPUT dCostSetup, 
                 OUTPUT cCostUOM,
                 OUTPUT v-cost, 
+                OUTPUT cVendorItemID,
                 OUTPUT lError, 
                 OUTPUT cMessage).  
                

--- a/Source/jc/b-jobmat.w
+++ b/Source/jc/b-jobmat.w
@@ -1334,6 +1334,7 @@ PROCEDURE new-rm-i-no PRIVATE :
   DEF VAR v-cost LIKE job-mat.std-cost NO-UNDO.
   DEF VAR v-cost-m LIKE job-mat.cost-m NO-UNDO.
   DEF VAR j AS INT NO-UNDO.
+  DEFINE VARIABLE cVendorItemID  AS CHARACTER NO-UNDO.
   
   DO WITH FRAME {&FRAME-NAME}:
     FIND FIRST ITEM
@@ -1482,6 +1483,7 @@ PROCEDURE new-rm-i-no PRIVATE :
                     OUTPUT dCostSetup, 
                     OUTPUT cCostUOM,
                     OUTPUT v-cost, 
+                    OUTPUT cVendorItemID,
                     OUTPUT lError, 
                     OUTPUT cMessage).  
                

--- a/Source/po/POProcs.p
+++ b/Source/po/POProcs.p
@@ -537,6 +537,7 @@ PROCEDURE pRecalculateCostsPOLine PRIVATE:
     DEFINE VARIABLE dCostPerUOMAdders AS DECIMAL NO-UNDO.
     DEFINE VARIABLE dCostSetupAdders AS DECIMAL NO-UNDO.
     DEFINE VARIABLE cAdderText AS CHARACTER NO-UNDO.
+    DEFINE VARIABLE cVendorItemID AS CHARACTER NO-UNDO.
     
     FOR bf-po-ordl NO-LOCK 
         WHERE ROWID(bf-po-ordl) EQ ipriPOOrdl
@@ -587,6 +588,7 @@ PROCEDURE pRecalculateCostsPOLine PRIVATE:
             OUTPUT dCostSetup, 
             OUTPUT cCostUOM,
             OUTPUT dCostTotal, 
+            OUTPUT cVendorItemID,
             OUTPUT lError, 
             OUTPUT cMessage).  
         

--- a/Source/po/RecostBoardPO.p
+++ b/Source/po/RecostBoardPO.p
@@ -192,6 +192,7 @@ PROCEDURE GetNewCostsN:
     DEFINE VARIABLE dCostTotal AS DECIMAL NO-UNDO.
     DEFINE VARIABLE lError AS LOGICAL NO-UNDO.
     DEFINE VARIABLE cMessage AS CHARACTER NO-UNDO.
+    DEFINE VARIABLE cVendorItemID AS CHARACTER NO-UNDO.
     
     FOR EACH ttPOGroups 
         WHERE ttPOGroups.Multi:
@@ -217,6 +218,7 @@ PROCEDURE GetNewCostsN:
             OUTPUT dCostSetup, 
             OUTPUT cCostUOM,
             OUTPUT dCostTotal, 
+            OUTPUT cVendorItemID,
             OUTPUT lError, 
             OUTPUT cMessage).      
             

--- a/Source/po/d-poordlN.w
+++ b/Source/po/d-poordlN.w
@@ -4763,6 +4763,7 @@ PROCEDURE pCreateAndUpdateAdders PRIVATE :
     DEFINE VARIABLE cCostUOM    AS CHARACTER NO-UNDO.
     DEFINE VARIABLE lError      AS LOGICAL   NO-UNDO.
     DEFINE VARIABLE cMessage    AS CHARACTER NO-UNDO.
+    DEFINE VARIABLE cVendorItemID AS CHARACTER NO-UNDO.
    
     DEFINE BUFFER bf-job-mat FOR job-mat.
     
@@ -4831,7 +4832,8 @@ PROCEDURE pCreateAndUpdateAdders PRIVATE :
                 OUTPUT dCostPerUOM, 
                 OUTPUT dCostSetup, 
                 OUTPUT cCostUOM,
-                OUTPUT dCostTotal, 
+                OUTPUT dCostTotal,
+                OUTPUT cVendorItemID,
                 OUTPUT lError, 
                 OUTPUT cMessage
                 ).  
@@ -5005,6 +5007,7 @@ PROCEDURE po-adder2 :
 
     DEFINE VARIABLE lError   AS LOGICAL   NO-UNDO.
     DEFINE VARIABLE cMessage AS CHARACTER NO-UNDO.
+    DEFINE VARIABLE cVendorItemID AS CHARACTER NO-UNDO.
     
     FIND xjob-mat WHERE RECID(xjob-mat) EQ ip-recid1 NO-LOCK.
 
@@ -5079,6 +5082,7 @@ PROCEDURE po-adder2 :
                 OUTPUT dCostSetup, 
                 OUTPUT cCostUOM,
                 OUTPUT dCostTotal, 
+                OUTPUT cVendorItemID,
                 OUTPUT lError, 
                 OUTPUT cMessage
                 ).  
@@ -6779,6 +6783,7 @@ PROCEDURE vend-cost :
     DEFINE VARIABLE dAddersSetupCost AS DECIMAL   NO-UNDO.
     DEFINE VARIABLE dQtyInCostUOM    AS DECIMAL   NO-UNDO.
     DEFINE VARIABLE dTotalCost       AS DECIMAL   NO-UNDO.
+    DEFINE VARIABLE cVendorItemID    AS CHARACTER NO-UNDO.
     
     RUN zero-vend-cost-related.
     EMPTY TEMP-TABLE tt-ei.
@@ -6831,7 +6836,8 @@ PROCEDURE vend-cost :
                 OUTPUT dCostPerUOM, 
                 OUTPUT dCostSetup, 
                 OUTPUT cCostUOM,
-                OUTPUT dCostTotal, 
+                OUTPUT dCostTotal,
+                OUTPUT cVendorItemID,
                 OUTPUT lError, 
                 OUTPUT cMessage).  
             RUN Conv_ValueFromUOMtoUOM(cocode, 
@@ -6867,6 +6873,7 @@ PROCEDURE vend-cost :
                 OUTPUT dCostSetup, 
                 OUTPUT cCostUOM,
                 OUTPUT dCostTotal, 
+                OUTPUT cVendorItemID,
                 OUTPUT lError, 
                 OUTPUT cMessage).        
             RUN Conv_ValueFromUOMtoUOM(cocode, 
@@ -6896,6 +6903,7 @@ PROCEDURE vend-cost :
                 po-ordl.setup:SCREEN-VALUE     = STRING(dCostSetup + dAddersSetupCost,po-ordl.setup:FORMAT)
                 po-ordl.cons-cost:SCREEN-VALUE = STRING(dCostPerUOMCons,po-ordl.cons-cost:FORMAT)
                 po-ordl.pr-uom:SCREEN-VALUE    = cCostUOM
+                po-ordl.vend-i-no:SCREEN-VALUE = cVendorItemID
                 .
             IF po-ordl.pr-uom:SCREEN-VALUE EQ "" THEN po-ordl.pr-uom:SCREEN-VALUE = "EA".
             IF po-ordl.pr-uom:SCREEN-VALUE NE po-ordl.pr-qty-uom:SCREEN-VALUE THEN 

--- a/Source/po/d-vndcstN.w
+++ b/Source/po/d-vndcstN.w
@@ -476,6 +476,7 @@ PROCEDURE build-table :
   DEFINE VARIABLE cCostUOM    AS CHARACTER NO-UNDO.
   DEFINE VARIABLE lError   AS LOGICAL   NO-UNDO.
   DEFINE VARIABLE cMessage AS CHARACTER NO-UNDO. 
+  DEFINE VARIABLE cVendorItemID AS CHARACTER NO-UNDO.
         
   FOR EACH bf-report NO-LOCK WHERE bf-report.term-id EQ v-term :
       FIND report WHERE ROWID(report) EQ ROWID(bf-report) EXCLUSIVE-LOCK.
@@ -538,7 +539,8 @@ PROCEDURE build-table :
               OUTPUT dCostPerUOM, 
               OUTPUT dCostSetup, 
               OUTPUT cCostUOM,
-              OUTPUT dCostTotal, 
+              OUTPUT dCostTotal,
+              OUTPUT cVendorItemID,
               OUTPUT lError, 
               OUTPUT cMessage).  
         

--- a/Source/po/po-adder.p
+++ b/Source/po/po-adder.p
@@ -33,6 +33,7 @@ DEFINE VARIABLE cCostUOM    AS CHARACTER NO-UNDO.
 DEFINE VARIABLE lError      AS LOGICAL   NO-UNDO.
 DEFINE VARIABLE cMessage    AS CHARACTER NO-UNDO.
 DEFINE VARIABLE hdPOProcs   AS HANDLE    NO-UNDO.
+DEFINE VARIABLE cVendorItemID AS CHARACTER NO-UNDO.
 
 def buffer xjob-mat for job-mat.
 
@@ -96,6 +97,7 @@ do with frame po-ordlf:
             OUTPUT dCostSetup, 
             OUTPUT cCostUOM,
             OUTPUT dCostTotal, 
+            OUTPUT cVendorItemID,
             OUTPUT lError, 
             OUTPUT cMessage).  
             

--- a/Source/system/VendorCostProcs.p
+++ b/Source/system/VendorCostProcs.p
@@ -882,6 +882,7 @@ PROCEDURE GetVendorCost:
     DEFINE OUTPUT PARAMETER opdCostSetup AS DECIMAL NO-UNDO.
     DEFINE OUTPUT PARAMETER opcCostUOM AS CHARACTER NO-UNDO.
     DEFINE OUTPUT PARAMETER opdCostTotal AS DECIMAL NO-UNDO.
+    DEFINE OUTPUT PARAMETER opcVendorItem AS CHARACTER NO-UNDO.
     DEFINE OUTPUT PARAMETER oplError AS LOGICAL NO-UNDO.
     DEFINE OUTPUT PARAMETER opcMessage AS CHARACTER NO-UNDO.
 
@@ -899,7 +900,8 @@ PROCEDURE GetVendorCost:
     IF NOT oplError AND AVAILABLE bf-vendItemCost THEN 
     DO:
         ASSIGN 
-            opcCostUOM = bf-vendItemCost.vendorUOM.
+            opcCostUOM = bf-vendItemCost.vendorUOM
+            opcVendorItem = bf-vendItemCost.vendorItemID.  MESSAGE "vendor cost process opcVendorItem " VIEW-AS ALERT-BOX ERROR.
         IF opcCostUOM NE ipcQuantityUOM THEN 
         DO:  
             RUN pConvertQuantity(ipcCompany, ipcItemID, ipcItemType, ipdQuantity, ipcQuantityUOM, opcCostUOM, 
@@ -1823,7 +1825,7 @@ PROCEDURE pBuildVendorCostFromReportUsingNewTables PRIVATE:
     DEFINE VARIABLE cCostUOM    AS CHARACTER NO-UNDO.
     DEFINE VARIABLE lError      AS LOGICAL   NO-UNDO.
     DEFINE VARIABLE cMessage    AS CHARACTER NO-UNDO.
-      
+    DEFINE VARIABLE cVendorItemID AS CHARACTER NO-UNDO.  
     DEFINE VARIABLE cRtnChar    AS CHARACTER NO-UNDO.
     DEFINE VARIABLE lRecFound   AS LOGICAL   NO-UNDO.
     
@@ -1899,7 +1901,8 @@ PROCEDURE pBuildVendorCostFromReportUsingNewTables PRIVATE:
                 OUTPUT dCostPerUOM, 
                 OUTPUT dCostSetup, 
                 OUTPUT cCostUOM,
-                OUTPUT dCostTotal, 
+                OUTPUT dCostTotal,
+                OUTPUT cVendorItemID,
                 OUTPUT lError, 
                 OUTPUT cMessage
                 ).  

--- a/Source/system/VendorCostProcs.p
+++ b/Source/system/VendorCostProcs.p
@@ -901,7 +901,7 @@ PROCEDURE GetVendorCost:
     DO:
         ASSIGN 
             opcCostUOM = bf-vendItemCost.vendorUOM
-            opcVendorItem = bf-vendItemCost.vendorItemID.  MESSAGE "vendor cost process opcVendorItem " VIEW-AS ALERT-BOX ERROR.
+            opcVendorItem = bf-vendItemCost.vendorItemID.  
         IF opcCostUOM NE ipcQuantityUOM THEN 
         DO:  
             RUN pConvertQuantity(ipcCompany, ipcItemID, ipcItemType, ipdQuantity, ipcQuantityUOM, opcCostUOM, 

--- a/Source/testers/t-povend.p
+++ b/Source/testers/t-povend.p
@@ -58,6 +58,7 @@ PROCEDURE GetVendorItemCost:
 
     DEFINE VARIABLE lError      AS LOGICAL   NO-UNDO.
     DEFINE VARIABLE cMessage    AS CHARACTER NO-UNDO.
+    DEFINE VARIABLE cVendorItemID AS CHARACTER NO-UNDO.
 
     iPO# = v-po# /*105207*/ .
     
@@ -106,7 +107,8 @@ PROCEDURE GetVendorItemCost:
                 OUTPUT dCostPerUOM, 
                 OUTPUT dCostSetup, 
                 OUTPUT cCostUOM,
-                OUTPUT dCostTotal, 
+                OUTPUT dCostTotal,
+                OUTPUT cVendorItemID,
                 OUTPUT lError, 
                 OUTPUT cMessage).  
               
@@ -150,6 +152,7 @@ PROCEDURE GetVendorItemCost:
                 OUTPUT dCostSetup, 
                 OUTPUT cCostUOM,
                 OUTPUT dCostTotal, 
+                OUTPUT cVendorItemID,
                 OUTPUT lError, 
                 OUTPUT cMessage).  
         END.

--- a/Source/util/ImportPo.p
+++ b/Source/util/ImportPo.p
@@ -600,6 +600,7 @@ PROCEDURE vend-cost PRIVATE:
     DEFINE VARIABLE cMessage        AS CHARACTER NO-UNDO.
     DEFINE VARIABLE dCostPerUOMCons AS DECIMAL   NO-UNDO.
     DEFINE VARIABLE dCostGrandTotal AS DECIMAL   NO-UNDO.
+    DEFINE VARIABLE cVendorItemID   AS CHARACTER NO-UNDO.
     
     DEFINE BUFFER bff-po-ord FOR po-ord.
     DEFINE BUFFER bff-po-ordl FOR po-ordl.
@@ -634,6 +635,7 @@ PROCEDURE vend-cost PRIVATE:
                 OUTPUT dCostSetup, 
                 OUTPUT cCostUOM,
                 OUTPUT dCostTotal, 
+                OUTPUT cVendorItemID,
                 OUTPUT lError, 
                 OUTPUT cMessage).  
             RUN Conv_ValueFromUOMtoUOM(bff-po-ordl.company, 
@@ -667,7 +669,8 @@ PROCEDURE vend-cost PRIVATE:
                 OUTPUT dCostPerUOM, 
                 OUTPUT dCostSetup, 
                 OUTPUT cCostUOM,
-                OUTPUT dCostTotal, 
+                OUTPUT dCostTotal,
+                OUTPUT cVendorItemID,
                 OUTPUT lError, 
                 OUTPUT cMessage).        
             RUN Conv_ValueFromUOMtoUOM(bff-po-ordl.company, 


### PR DESCRIPTION
Please review this change and merge into development branch 
Files - Source/VendorCostTester.p
Source/est/EstimateCalcProcs.p
Source/est/getVendCost.i
Source/est/getVendorCostinQtyUOM.p
Source/est/RecostBoardEst.p
Source/jc/b-jobfarm.w
Source/jc/b-jobmat.w
Source/po/d-poordlN.w
Source/po/d-vndcstN.w
Source/po/po-adder.p
Source/po/POProcs.p
Source/po/RecostBoardPO.p
Source/system/VendorCostProcs.p
Source/testers/t-povend.p
Source/util/ImportPo.p